### PR TITLE
Feat/backend/docker setup

### DIFF
--- a/typing-server/Dockerfile
+++ b/typing-server/Dockerfile
@@ -1,0 +1,29 @@
+# 基本イメージ
+FROM golang:1.22.0 as builder
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# ソースコードをコピー
+COPY . .
+
+# 依存関係をインストール
+RUN go mod download
+
+# アプリケーションをビルド
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o server ./api/cmd/main.go
+
+# 実行イメージ
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+
+# tzdataパッケージのインストール
+RUN apk --no-cache add tzdata
+
+WORKDIR /root
+
+# ビルドしたバイナリをコピー
+COPY --from=builder /app/server .
+
+# アプリケーションの実行
+CMD ["./server"]

--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -23,12 +23,13 @@ func main() {
 	mysqlConfig := &mysql.Config{
 		DBName:    "typing-db",
 		User:      "user",
-		Passwd:    "password",       // 環境変数から取得するか、直接指定
-		Addr:      "db:33061", // Docker Compose内でのサービス名とポート
+		Passwd:    "password", // 環境変数から取得するか、直接指定
+		Net:       "tcp",
+		Addr:      "db:3306", // Docker Compose内でのサービス名とポート
 		ParseTime: true,
 		Loc:       jst,
 	}
-	
+
 	entClient, err := ent.Open("mysql", mysqlConfig.FormatDSN())
 	if err != nil {
 		logger.Error("failed to open ent client", fmt.Errorf("error: %w", err))

--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -16,7 +16,6 @@ import (
 )
 
 func main() {
-	// 標準のログパッケージを使用
 	logger := slog.Default()
 
 	// タイムゾーンの設定
@@ -43,9 +42,8 @@ func main() {
 		logger.Error("failed to open ent client: %v", err)
 		return
 	}
-	logger.Info("ent client is opened")
-
 	defer entClient.Close()
+	logger.Info("ent client is opened")
 
 	// スキーマの作成
 	if err := entClient.Schema.Create(context.Background()); err != nil {

--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/su-its/typing/typing-server/api/presenter"
+	"github.com/su-its/typing/typing-server/domain/repository/ent"
+)
+
+func main() {
+	logger := slog.Default()
+
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		logger.Error("failed to load location", fmt.Errorf("error: %w", err))
+	}
+
+	mysqlConfig := &mysql.Config{
+		DBName:    "typing-db",
+		User:      "root",
+		Passwd:    "password",
+		Addr:      "localhost:3306",
+		Net:       "tcp",
+		ParseTime: true,
+		Loc:       jst,
+	}
+
+	entClient, err := ent.Open("mysql", mysqlConfig.FormatDSN())
+	if err != nil {
+		logger.Error("failed to open ent client", fmt.Errorf("error: %w", err))
+	}
+
+	logger.Info("ent client is opened")
+
+	if err := entClient.Schema.Create(context.Background()); err != nil {
+		logger.Error("failed to create schema", fmt.Errorf("error: %w", err))
+	}
+
+	logger.Info("schema is created")
+
+	presenter.RegisterRoutes()
+	go func() {
+		logger.Info("server is running")
+		if err := http.ListenAndServe(":8080", nil); err != nil {
+			logger.Error("failed to listen and serve", fmt.Errorf("error: %w", err))
+		}
+	}()
+}

--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -79,7 +79,8 @@ func main() {
 		// シグナルを待機
 		<-sigChan
 		logger.Info("shutting down the server...")
-		if err := server.Shutdown(nil); err != nil {
+		ctx := context.TODO() // Use context.TODO() as a temporary placeholder
+		if err := server.Shutdown(ctx); err != nil {
 			logger.Error("error during server shutdown: %v", err)
 			errChan <- err // エラーをチャネルに送信
 		}

--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -22,26 +22,25 @@ func main() {
 
 	mysqlConfig := &mysql.Config{
 		DBName:    "typing-db",
-		User:      "root",
-		Passwd:    "password",
-		Addr:      "localhost:3306",
-		Net:       "tcp",
+		User:      "user",
+		Passwd:    "password",       // 環境変数から取得するか、直接指定
+		Addr:      "db:33061", // Docker Compose内でのサービス名とポート
 		ParseTime: true,
 		Loc:       jst,
 	}
-
+	
 	entClient, err := ent.Open("mysql", mysqlConfig.FormatDSN())
 	if err != nil {
 		logger.Error("failed to open ent client", fmt.Errorf("error: %w", err))
+	} else {
+		logger.Info("ent client is opened")
 	}
-
-	logger.Info("ent client is opened")
 
 	if err := entClient.Schema.Create(context.Background()); err != nil {
 		logger.Error("failed to create schema", fmt.Errorf("error: %w", err))
+	} else {
+		logger.Info("schema is created")
 	}
-
-	logger.Info("schema is created")
 
 	presenter.RegisterRoutes()
 	go func() {

--- a/typing-server/api/controller/system/health.go
+++ b/typing-server/api/controller/system/health.go
@@ -1,11 +1,20 @@
 package system
 
 import (
+	"log"
 	"net/http"
 )
 
 // HealthCheck はヘルスチェックのためのハンドラー関数です。
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("API is running"))
+	_, err := w.Write([]byte("API is running"))
+	if err != nil {
+		// エラーログを記録し、処理を終了します。
+		// 実際には、この時点でレスポンスヘッダーやボディがクライアントに送信されている可能性が高いため、
+		// http.Errorを呼び出すことは推奨されません。
+		// 代わりに、ログに記録するなどのサーバー側での対応が適切です。
+		log.Printf("failed to write response: %v", err)
+	}
 }
+

--- a/typing-server/api/controller/system/health.go
+++ b/typing-server/api/controller/system/health.go
@@ -1,7 +1,7 @@
 package system
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 )
 
@@ -14,7 +14,7 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 		// 実際には、この時点でレスポンスヘッダーやボディがクライアントに送信されている可能性が高いため、
 		// http.Errorを呼び出すことは推奨されません。
 		// 代わりに、ログに記録するなどのサーバー側での対応が適切です。
-		log.Printf("failed to write response: %v", err)
+		slog.Error("failed to write response: %v", err)
 	}
 }
 

--- a/typing-server/api/controller/system/health.go
+++ b/typing-server/api/controller/system/health.go
@@ -1,0 +1,11 @@
+package system
+
+import (
+	"net/http"
+)
+
+// HealthCheck はヘルスチェックのためのハンドラー関数です。
+func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("API is running"))
+}

--- a/typing-server/api/presenter/server.go
+++ b/typing-server/api/presenter/server.go
@@ -1,0 +1,11 @@
+package presenter
+
+import (
+	"net/http"
+
+	"github.com/su-its/typing/typing-server/api/controller/system"
+)
+
+func RegisterRoutes() {
+	http.HandleFunc("/health", system.HealthCheck)
+}

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -44,4 +44,3 @@ networks:
       driver: default
       config:
         - subnet: 172.28.1.0/24
-        

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -1,0 +1,28 @@
+version: '2.8'
+services:
+  db:
+    image: mysql:8.3.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: typing-db
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+    ports:
+      - "3305:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./api:/app
+    ports:
+      - "8079:8080"
+    environment:
+      - DB_HOST=db
+      - DB_USER=root
+      - DB_PASSWORD=password
+      - DB_NAME=devdb
+volumes:
+  db-data:

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -1,5 +1,7 @@
 services:
   api:
+    depends_on:
+      - db
     build:
       context: .
       dockerfile: Dockerfile
@@ -20,7 +22,7 @@ services:
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: password
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - db-data:/var/lib/mysql
     networks:

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -1,16 +1,4 @@
-version: '2.8'
 services:
-  db:
-    image: mysql:8.3.0
-    environment:
-      MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: typing-db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: password
-    ports:
-      - "3305:3306"
-    volumes:
-      - db-data:/var/lib/mysql
   api:
     build:
       context: .
@@ -18,11 +6,32 @@ services:
     volumes:
       - ./api:/app
     ports:
-      - "8079:8080"
+      - "8080:8080"
+    networks:
+      app_net:
+        ipv4_address: '172.28.1.3'
+    extra_hosts:
+      - 'db:172.28.1.5'
+  db:
+    image: mysql:8.3.0
     environment:
-      - DB_HOST=db
-      - DB_USER=root
-      - DB_PASSWORD=password
-      - DB_NAME=devdb
+      MYSQL_DATABASE: typing-db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      app_net:
+        ipv4_address: '172.28.1.5'
 volumes:
   db-data:
+networks:
+  app_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.1.0/24

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -44,3 +44,4 @@ networks:
       driver: default
       config:
         - subnet: 172.28.1.0/24
+        

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -1,7 +1,8 @@
 services:
   api:
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     build:
       context: .
       dockerfile: Dockerfile
@@ -15,6 +16,12 @@ services:
     extra_hosts:
       - 'db:172.28.1.5'
   db:
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 10
+      start_period: 30s
+
     image: mysql:8.3.0
     environment:
       MYSQL_DATABASE: typing-db

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -1,16 +1,4 @@
-version: '2.8'
 services:
-  db:
-    image: mysql:8.3.0
-    environment:
-      MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: typing-db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: password
-    ports:
-      - "3305:3306"
-    volumes:
-      - db-data:/var/lib/mysql
   api:
     build:
       context: .
@@ -18,11 +6,32 @@ services:
     volumes:
       - ./api:/app
     ports:
-      - "8079:8080"
+      - "8080:8080"
+    networks:
+      app_net:
+        ipv4_address: '172.28.1.3'
+    extra_hosts:
+      - 'db:172.28.1.5'
+  db:
+    image: mysql:8.3.0
     environment:
-      - DB_HOST=db
-      - DB_USER=root
-      - DB_PASSWORD=password
-      - DB_NAME=devdb
+      MYSQL_DATABASE: typing-db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - "33061:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      app_net:
+        ipv4_address: '172.28.1.5'
 volumes:
   db-data:
+networks:
+  app_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.1.0/24

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -44,4 +44,3 @@ networks:
       driver: default
       config:
         - subnet: 172.28.1.0/24
-        

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2.8'
+services:
+  db:
+    image: mysql:8.3.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: typing-db
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+    ports:
+      - "3305:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./api:/app
+    ports:
+      - "8079:8080"
+    environment:
+      - DB_HOST=db
+      - DB_USER=root
+      - DB_PASSWORD=password
+      - DB_NAME=devdb
+volumes:
+  db-data:

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -44,3 +44,4 @@ networks:
       driver: default
       config:
         - subnet: 172.28.1.0/24
+        

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -1,5 +1,8 @@
 services:
   api:
+    depends_on:
+      db:
+        condition: service_healthy
     build:
       context: .
       dockerfile: Dockerfile
@@ -13,6 +16,12 @@ services:
     extra_hosts:
       - 'db:172.28.1.5'
   db:
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 10
+      start_period: 30s
+
     image: mysql:8.3.0
     environment:
       MYSQL_DATABASE: typing-db
@@ -20,7 +29,7 @@ services:
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: password
     ports:
-      - "33061:3306"
+      - "3307:3306"
     volumes:
       - db-data:/var/lib/mysql
     networks:

--- a/typing-server/go.mod
+++ b/typing-server/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	entgo.io/ent v0.13.1
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/google/uuid v1.6.0
 )
 

--- a/typing-server/go.sum
+++ b/typing-server/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
<!--
## チケットへのリンク

- https://github.com/orgs/su-its/projects/example-hogehoge-fugafuga
-->
## やったこと

フロントエンドサイドが実装時に環境をdocker-compose upでビルドできるようにしました．
APIは簡単なヘルスチェックのみの実装，DBはentをとおして作成されるようにしました．
ルータ，エントリポイントについても作成しました．
docker-composeを作成しました

## やらないこと

具体的なAPIの実装(ヘルスチェック以外の)

## できるようになること（ユーザ目線）

多分みんなが環境をセットアップできるようになる

## できなくなること（ユーザ目線）

なし

## 動作確認

docker compose up --buidした．エラーが出ていた部分が以下のように治った
api-1  | 2024/03/02 06:14:51 ent client is opened
api-1  | 2024/03/02 06:14:52 schema is created
api-1  | 2024/03/02 06:14:52 server is running at http://localhost:8080
当該URL(http://localhost:8080/health)で「API is running」を確認しました

## その他

使用しているosによってDB→API起動順序にエラーがでるかもみたいな記事を読んだけど関係ないよな．．．
