### PR TITLE
フロントエンドのコンテナ立てるための Dockerfile を作成

### DIFF
--- a/typing-app/.dockerignore
+++ b/typing-app/.dockerignore
@@ -1,0 +1,4 @@
+.next
+docs
+node_modules
+README.md

--- a/typing-app/Dockerfile
+++ b/typing-app/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV production
 
 FROM base as deps
 COPY package.json bun.lockb ./
-RUN bun i
+RUN bun install
 
 # bypass node image on build and use bun on runtime
 # https://github.com/oven-sh/bun/issues/4795
@@ -16,9 +16,11 @@ COPY . .
 RUN npm run build
 
 FROM base as final
-COPY --from=build /app/public ./public
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
+USER bun
+
+COPY --from=build --chown=bun:bun /app/public ./public
+COPY --from=build --chown=bun:bun /app/.next/standalone ./
+COPY --from=build --chown=bun:bun /app/.next/static ./.next/static
 
 EXPOSE 3000
 ENV PORT 3000

--- a/typing-app/Dockerfile
+++ b/typing-app/Dockerfile
@@ -1,0 +1,27 @@
+FROM oven/bun:slim as base
+WORKDIR /app
+ENV NODE_ENV production
+
+FROM base as deps
+COPY package.json bun.lockb ./
+RUN bun i
+
+# bypass node image on build and use bun on runtime
+# https://github.com/oven-sh/bun/issues/4795
+FROM node:20.11-slim as build
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM base as final
+COPY --from=build /app/public ./public
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+
+EXPOSE 3000
+ENV PORT 3000
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["bun", "server.js"]

--- a/typing-app/next.config.mjs
+++ b/typing-app/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: "standalone",
+};
 
 export default nextConfig;


### PR DESCRIPTION
遅くなりましたがよろしくお願いします！

## チケットへのリンク

(省略)

## やったこと

- フロントエンドのコンテナを立てられるようにした

## やらないこと

- github actions の設定など

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

:ok: build
```
$ docker build --no-cache --tag=su-its-typing-typing-app:latest .
[+] Building 83.9s (18/18) FINISHED                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                          0.0s
 => => transferring dockerfile: 675B                                                                          0.0s
 => [internal] load metadata for docker.io/library/node:20.11-slim                                            1.0s
 => [internal] load metadata for docker.io/oven/bun:slim                                                      0.9s
 => [internal] load .dockerignore                                                                             0.0s
 => => transferring context: 74B                                                                              0.0s
 => [internal] load build context                                                                             0.0s
 => => transferring context: 2.43kB                                                                           0.0s
 => [base 1/2] FROM docker.io/oven/bun:slim@sha256:d4b2159a0bb19b1ba9ecd0970007ef946f23c8543c08310c47af7d10c  0.0s
 => [build 1/5] FROM docker.io/library/node:20.11-slim@sha256:474988d2fa8ad6321db19dc941af70202b163fca06a6b4  0.0s
 => CACHED [base 2/2] WORKDIR /app                                                                            0.0s
 => CACHED [build 2/5] WORKDIR /app                                                                           0.0s
 => [deps 1/2] COPY package.json bun.lockb ./                                                                 0.1s
 => [deps 2/2] RUN bun install                                                                               16.5s
 => [build 3/5] COPY --from=deps /app/node_modules ./node_modules                                             5.7s
 => [build 4/5] COPY . .                                                                                      0.2s
 => [build 5/5] RUN npm run build                                                                            51.2s
 => [final 1/3] COPY --from=build --chown=bun:bun /app/public ./public                                        0.1s
 => [final 2/3] COPY --from=build --chown=bun:bun /app/.next/standalone ./                                    0.8s
 => [final 3/3] COPY --from=build --chown=bun:bun /app/.next/static ./.next/static                            0.2s
 => exporting to image                                                                                        0.6s
 => => exporting layers                                                                                       0.5s
 => => writing image sha256:2a29a6f745c0dcfebbd78a0c712dc797525e2fd1ce4fc15b58e71e481af70f79                  0.0s
 => => naming to docker.io/library/su-its-typing-typing-app:latest                                            0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```

:ok: run
```
$ docker run --rm -p 3000:3000 su-its-typing-typing-app:latest
   ▲ Next.js 14.1.0
   - Local:        http://localhost:3000
   - Network:      http://0.0.0.0:3000

 ✓ Ready in 332ms
```
ブラウザで`http://localhost:3000`にアクセスし、`Home View`と表示されることを確認しました。

## その他

- Dockerfile に bun イメージだけじゃなくて node イメージも含まれているのはなぜ？
  - 使用している[oven/bun](https://hub.docker.com/r/oven/bun)イメージでは Next.js のビルドが一生終わらない不具合[^1]があったため
  - この対策としてビルドだけは node イメージを使って `npm run build` している(実行時は bun)
- next.config.mjs の `output: "standalone"` とは？
  - docker で動かすときのおまじない(詳しくは→[公式ドキュメント](https://nextjs.org/docs/app/building-your-application/deploying#docker-image) および [公式のコンテナ作成例](https://github.com/vercel/next.js/tree/f9aec9005ae2136076660a026e178ee4206bc5a4/examples/with-docker)を参照)
- #5 への PR であって develop への PR じゃないんですがよろしくお願いします

[^1]: `https://github.com/oven-sh/bun/issues/4795`