### PR TITLE
ci[typing-app]: PR時にビルドする

### DIFF
--- a/.github/actions/prepare-nodemodules/action.yml
+++ b/.github/actions/prepare-nodemodules/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: actions/cache@v4
       id: cache
-      working-directory: ${{ inputs.root }}
+      shell: bash
       with:
         path: |
           ~/.bun/install/cache
@@ -26,6 +26,7 @@ runs:
       with:
         bun-version: latest
     - name: Install dependencies
+      shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.root }}
       run: bun install

--- a/.github/actions/prepare-nodemodules/action.yml
+++ b/.github/actions/prepare-nodemodules/action.yml
@@ -1,0 +1,31 @@
+name: Prepare node_modules
+
+description: Install Dependencies using Bun. If cache hit, do nothing.
+
+inputs:
+  root:
+    description: |-
+      An absolute path to the directory where contains package.json.
+      Required
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      id: cache
+      working-directory: ${{ inputs.root }}
+      with:
+        path: |
+          ~/.bun/install/cache
+          ${{ inputs.root }}/.next/cache
+        key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lockb') }}
+        restore-keys: ${{ runner.os }}-bun-cache-
+    - uses: oven-sh/setup-bun@v1
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        bun-version: latest
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      working-directory: ${{ inputs.root }}
+      run: bun install

--- a/.github/actions/prepare-nodemodules/action.yml
+++ b/.github/actions/prepare-nodemodules/action.yml
@@ -14,7 +14,6 @@ runs:
   steps:
     - uses: actions/cache@v4
       id: cache
-      shell: bash
       with:
         path: |
           ~/.bun/install/cache

--- a/.github/actions/prepare-nodemodules/action.yml
+++ b/.github/actions/prepare-nodemodules/action.yml
@@ -16,7 +16,7 @@ runs:
       id: cache
       with:
         path: |
-          ~/.bun/install/cache
+          ${{ inputs.root }}/node_modules
           ${{ inputs.root }}/.next/cache
         key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lockb') }}
         restore-keys: ${{ runner.os }}-bun-cache-

--- a/.github/actions/prepare-nodemodules/action.yml
+++ b/.github/actions/prepare-nodemodules/action.yml
@@ -18,7 +18,7 @@ runs:
         path: |
           ${{ inputs.root }}/node_modules
           ${{ inputs.root }}/.next/cache
-        key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lockb') }}
+        key: ${{ runner.os }}-bun-cache-${{ hashFiles('**/bun.lockb') }}
         restore-keys: ${{ runner.os }}-bun-cache-
     - uses: oven-sh/setup-bun@v1
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,4 +1,4 @@
-name: nodejsci
+name: build-app
 
 on:
   pull_request:
@@ -6,12 +6,9 @@ on:
       - develop
       - main
     paths:
-      - .github/workflows/nodejsci.yml
+      - .github/workflows/build-app.yml
       - "typing-app/**"
   workflow_dispatch:
-
-permissions:
-  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,10 +22,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-nodemodules
         with:
           root: ${{ github.workspace }}/typing-app
-      - name: Try to build
+      - name: Build Next.js Project
         run: npm run build

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: .github/actions/prepare-nodemodules
+      - uses: ./.github/actions/prepare-nodemodules
         with:
           root: ${{ github.workspace }}/typing-app
       - name: Try to build

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - main
+  workflow_dispatch:
   paths:
     - "typing-app/**"
 

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -5,13 +5,15 @@ on:
     branches:
       - develop
       - main
+    paths:
+      - "typing-app/**"
   pull_request:
     branches:
       - develop
       - main
+    paths:
+      - "typing-app/**"
   workflow_dispatch:
-  paths:
-    - "typing-app/**"
 
 defaults:
   run:

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -18,9 +18,16 @@ on:
       - "typing-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
-    working-directory: ./typing-app
+    working-directory: typing-app
 
 jobs:
   build:
@@ -28,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/prepare-nodemodules
+      - uses: .github/actions/prepare-nodemodules
         with:
           root: ${{ github.workspace }}/typing-app
       - name: Try to build

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -11,7 +11,6 @@ on:
       - "typing-app/**"
   pull_request:
     branches:
-      - "ci/**"
       - develop
       - main
     paths:
@@ -34,19 +33,3 @@ jobs:
           root: ${{ github.workspace }}/typing-app
       - name: Try to build
         run: npm run build
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache/restore@v4
-        with:
-          path: |
-            ${{ github.workspace }}/typing-app/node_modules
-            ${{ github.workspace }}/typing-app/.next/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('typing-app/bun.lockb') }}
-          fail-on-cache-miss: true
-      - name: Run lint
-        run: npm run lint

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -3,15 +3,19 @@ name: CI (typing-app)
 on:
   push:
     branches:
+      - "ci/**"
       - develop
       - main
     paths:
+      - .github/workflows/nodejsci.yml
       - "typing-app/**"
   pull_request:
     branches:
+      - "ci/**"
       - develop
       - main
     paths:
+      - .github/workflows/nodejsci.yml
       - "typing-app/**"
   workflow_dispatch:
 

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -1,4 +1,4 @@
-name: CI (typing-app)
+name: nodejsci
 
 on:
   push:

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -1,13 +1,6 @@
 name: nodejsci
 
 on:
-  push:
-    branches:
-      - develop
-      - main
-    paths:
-      - .github/workflows/nodejsci.yml
-      - "typing-app/**"
   pull_request:
     branches:
       - develop

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -29,21 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        id: cache
+      - uses: ./.github/actions/prepare-nodemodules
         with:
-          path: |
-            ${{ github.workspace }}/typing-app/node_modules
-            ${{ github.workspace }}/typing-app/.next/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('typing-app/bun.lockb') }}
-          restore-keys: ${{ runner.os }}-bun-cache-
-      - uses: oven-sh/setup-bun@v1
-        if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          bun-version: latest
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bun install
+          root: ${{ github.workspace }}/typing-app
       - name: Try to build
         run: npm run build
 

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -3,7 +3,6 @@ name: nodejsci
 on:
   push:
     branches:
-      - "ci/**"
       - develop
       - main
     paths:

--- a/.github/workflows/nodejsci.yml
+++ b/.github/workflows/nodejsci.yml
@@ -1,0 +1,57 @@
+name: CI (typing-app)
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+  paths:
+    - "typing-app/**"
+
+defaults:
+  run:
+    working-directory: ./typing-app
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ${{ github.workspace }}/typing-app/node_modules
+            ${{ github.workspace }}/typing-app/.next/cache
+          key: ${{ runner.os }}-bun-cache-${{ hashFiles('typing-app/bun.lockb') }}
+          restore-keys: ${{ runner.os }}-bun-cache-
+      - uses: oven-sh/setup-bun@v1
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bun install
+      - name: Try to build
+        run: npm run build
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/typing-app/node_modules
+            ${{ github.workspace }}/typing-app/.next/cache
+          key: ${{ runner.os }}-bun-cache-${{ hashFiles('typing-app/bun.lockb') }}
+          fail-on-cache-miss: true
+      - name: Run lint
+        run: npm run lint


### PR DESCRIPTION
## やったこと

- ~~nodejsci.yml~~ build-app.yml の追加
  - develop ブランチへの PR 時に `npm run build` ~~し、それが成功したら `npm run lint` も~~やる
  - ~~bunを使ってるけどnodeの知見で書いたので何となくというのとワンチャンbunやめるかもしれないのでnodejsという文言が入ってる~~
  - typing-app の app を取って build-app にした

## やらないこと

- ~~workflow file の分割等~~
- reviewdog の導入等

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 手元で [act](https://nektosact.com/) による動作確認を行った
  - act はローカルで Github Actions の動作確認を行えるツールです
  - キャッシュがある場合と無い場合、それからTypeScriptの文法エラーで失敗する場合、すべてについて想定通り動いてました
