### PR TITLE
fix[typing-server]: 接続するDBのアドレスを環境変数で指定できるように

### DIFF
--- a/typing-server/api/cmd/main.go
+++ b/typing-server/api/cmd/main.go
@@ -25,15 +25,20 @@ func main() {
 		return
 	}
 
+	var addr = os.Getenv("DB_ADDR")
+	if addr == "" {
+		addr = "db:3306" // アドレス（Docker Compose内でのサービス名とポート）
+	}
+
 	// MySQLの接続設定
 	mysqlConfig := &mysql.Config{
 		DBName:    "typing-db", // データベース名
 		User:      "user",      // ユーザー名
 		Passwd:    "password",  // パスワード
 		Net:       "tcp",       // ネットワークタイプ
-		Addr:      "db:3306",   // アドレス（Docker Compose内でのサービス名とポート）
-		ParseTime: true,        // 時刻をtime.Timeで解析する
-		Loc:       jst,         // タイムゾーン
+		Addr:      addr,
+		ParseTime: true, // 時刻をtime.Timeで解析する
+		Loc:       jst,  // タイムゾーン
 	}
 
 	// entクライアントの初期化

--- a/typing-server/docker-compose.dev.yml
+++ b/typing-server/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./api:/app
+    environment:
+      DB_ADDR: ${DB_ADDR:-db:3306}
     ports:
       - "8080:8080"
     networks:

--- a/typing-server/docker-compose.yml
+++ b/typing-server/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./api:/app
+    environment:
+      DB_ADDR: ${DB_ADDR:-db:3306}
     ports:
       - "8080:8080"
     networks:


### PR DESCRIPTION
## チケットへのリンク

(省略)

## やったこと

- データベースのアドレスを環境変数 `DB_ADDR` から設定するように変更した
  - 動作確認のために Cloud Run にデプロイするが、その段階で希望の値をセットしたかったため

## やらないこと

- ドキュメントの整備
  - 一応、書いたには書いたんですがここに含めると時間がかかりそうだったので省略しています

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 異なる環境変数を渡して go のプログラムが異なる接続先に接続しに行くことを確認した
```bash
# Error response from daemon: Address already in use と出るので
# ここで api サービスは削除しておきます (docker compose up -d api すれば元に戻ります)
$ docker compose down api
```
:ok_man: まず適当なアドレスを指定すると繋がらないことを確認
```bash
docker compose run --rm --env DB_ADDR=192.168.0.1:3306 api
[+] Creating 1/0
 ✔ Container typing-server-db-1  Running                                                                                                                                               0.0s
2024/03/10 05:04:21 INFO ent client is opened
2024/03/10 05:04:23 ERROR failed to create schema: %v !BADKEY="mysql: querying mysql version dial tcp 192.168.0.1:3306: connect: connection refused"
```
:ok_man: 次に docker-compose.yml の db サービスに割り当てられたアドレス(db や typing-server-db-1 も同様)で繋がることを確認
```bash
$ docker compose run --rm --env DB_ADDR=172.28.1.5:3306 api
[+] Creating 1/0
 ✔ Container typing-server-db-1  Running                                                                                                                                               0.0s
2024/03/10 05:00:11 INFO ent client is opened
2024/03/10 05:00:11 INFO schema is created
2024/03/10 05:00:11 INFO server is running at Addr :8080
^C2024/03/10 05:00:12 INFO received signal: %s !BADKEY=interrupt
^C2024/03/10 05:00:13 INFO shutting down the server...
2024/03/10 05:00:13 INFO server exited
```
