### PR TITLE
bun run build でもうまくいきそうなので npm を使うのをやめた

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           root: ${{ github.workspace }}/typing-app
       - name: Build Next.js Project
-        run: npm run build
+        run: bun run build


### PR DESCRIPTION
## やったこと

- typing-app の CI で`npm run build` していたのを `bun run build` するように変更した

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- ~~マージされないと確認できない。してない~~ そんなことなかった。ばっちりいけた https://github.com/su-its/typing/actions/runs/8410046392/job/23028023883

## その他

全体として bun を使っているにもかかわらず、今までビルドだけ `npm run build` としていたのはなぜか bun だと next build が途中で落ちるからでした。

このワークフローを導入したPR→ #11 (ここ読んだら理由が書いてあると思ったのだけれど書いてなかった…)