### PR TITLE
Feat/game screen/start button fixed

### DIFF
--- a/typing-app/src/components/templates/GamePre.tsx
+++ b/typing-app/src/components/templates/GamePre.tsx
@@ -1,12 +1,20 @@
-import { Box, Button, Text } from "@chakra-ui/react";
-import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+import React, { useEffect } from "react";
 import { SubGamePageProps } from "../pages/Game";
 
 const GamePre: React.FC<SubGamePageProps> = ({ nextPage }) => {
+  // Spaceキーを押したときに実行する関数
+  const handleSpaceButtonDown: React.KeyboardEventHandler = async (e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();  // ページのスクロールなどのデフォルト動作を防止
+      // 次のページへ
+      nextPage();
+    }
+  };
+
   return (
-    <Box>
+    <Box onKeyDown={handleSpaceButtonDown}>
       <Text>GamePre screen</Text>
-      <Button onClick={nextPage}>start</Button>
     </Box>
   );
 };

--- a/typing-app/src/components/templates/GamePre.tsx
+++ b/typing-app/src/components/templates/GamePre.tsx
@@ -3,17 +3,25 @@ import React, { useEffect } from "react";
 import { SubGamePageProps } from "../pages/Game";
 
 const GamePre: React.FC<SubGamePageProps> = ({ nextPage }) => {
-  // Spaceキーを押したときに実行する関数
-  const handleSpaceButtonDown: React.KeyboardEventHandler = async (e) => {
-    if (e.code === 'Space') {
-      e.preventDefault();  // ページのスクロールなどのデフォルト動作を防止
-      // 次のページへ
-      nextPage();
+  useEffect(() => {
+    // Spaceキーを押したときに実行する関数
+    const handleSpaceButtonDown = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        e.preventDefault();  // ページのスクロールなどのデフォルト動作を防止
+        // 次のページへ
+        nextPage();
+      }
+    };
+
+    window.addEventListener("keydown", handleSpaceButtonDown)
+
+    return () => {
+      window.removeEventListener("keydown", handleSpaceButtonDown)
     }
-  };
+  }, [nextPage]);
 
   return (
-    <Box onKeyDown={handleSpaceButtonDown}>
+    <Box>
       <Text>GamePre screen</Text>
     </Box>
   );


### PR DESCRIPTION
## やったこと

- 空白キー押下で次のページ(GameTyping.tsxの中身)に遷移

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 空白キー押下で次のページに遷移

## できなくなること（ユーザ目線）

- 仮置きのボタンを廃止

## 動作確認

- `bun run build`して動作することを確認

## その他

- 無し
