### PR TITLE
Ci/front/actions bun to yarn migration

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -26,12 +26,14 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
       # Corepack enable をしておけば package.json の packageManager を読んで適切なバージョンの yarn を使ってくれる。
       # ただし非公式な方法であり、あくまでワークアラウンド。
       # https://github.com/actions/setup-node/issues/480#issuecomment-1820622085
       # > enable corepack **before** setup-node.
       - name: Enable Corepack
         run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -40,5 +42,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
+
       - name: Build Next.js Project
         run: yarn build

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -26,8 +26,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/prepare-nodemodules
+      # Corepack enable をしておけば package.json の packageManager を読んで適切なバージョンの yarn を使ってくれる。
+      # ただし非公式な方法であり、あくまでワークアラウンド。
+      # https://github.com/actions/setup-node/issues/480#issuecomment-1820622085
+      # > enable corepack **before** setup-node.
+      - name: Enable Corepack
+        run: corepack enable
+      - uses: actions/setup-node@v4
         with:
-          root: ${{ github.workspace }}/typing-app
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: typing-app
+
+      - name: Install Dependencies
+        run: yarn
       - name: Build Next.js Project
-        run: npm run build
+        run: yarn build

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'yarn'
-          cache-dependency-path: typing-app
+          cache-dependency-path: typing-app/yarn.lock
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
## やったこと

- bun を使っていた CI を node や yarn に置き換えた

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- ローカルで動作確認した。ログを添付する。 [202403261656-act-run-log.txt](https://github.com/su-its/typing/files/14754592/202403261656-act-run-log.txt)

## その他

- ログ↑を見ると今の時点では base branch の yarn.lock が v1 を使っている？ので yarn v4 では動いてませんが、base branch が何とかなればなんとかなると思います
