### PR TITLE
yarn の移行に伴って壊れた CI を直す

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/docker/compose.ci.yaml
+++ b/docker/compose.ci.yaml
@@ -4,7 +4,6 @@ services:
     build:
       context: ../typing-app
       cache_from:
-        - oven/bun:slim
         - node:20.11-slim
   api:
     image: ghcr.io/su-its/typing-server:dev

--- a/typing-app/.dockerignore
+++ b/typing-app/.dockerignore
@@ -1,4 +1,6 @@
+.dockerignore
 .next
+.yarn
 docs
 node_modules
 README.md

--- a/typing-app/Dockerfile
+++ b/typing-app/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.11-slim as base
 WORKDIR /app
 ENV NODE_ENV production
@@ -5,7 +6,7 @@ RUN corepack enable yarn # to read "packageManager" in package.json
 
 FROM base as build
 COPY package.json yarn.lock .yarnrc.yml ./
-RUN yarn --immutable
+RUN --mount=type=cache,target=/root/.cache/yarn/v6 yarn --immutable
 
 COPY . .
 RUN yarn build

--- a/typing-app/Dockerfile
+++ b/typing-app/Dockerfile
@@ -1,29 +1,24 @@
-FROM oven/bun:slim as base
+FROM node:20.11-slim as base
 WORKDIR /app
 ENV NODE_ENV production
+RUN corepack enable yarn # to read "packageManager" in package.json
 
-FROM base as deps
-COPY package.json bun.lockb ./
-RUN bun install
+FROM base as build
+COPY package.json yarn.lock .yarnrc.yml ./
+RUN yarn --immutable
 
-# bypass node image on build and use bun on runtime
-# https://github.com/oven-sh/bun/issues/4795
-FROM node:20.11-slim as build
-WORKDIR /app
-
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+RUN yarn build
 
 FROM base as final
-USER bun
+USER node
 
-COPY --from=build --chown=bun:bun /app/public ./public
-COPY --from=build --chown=bun:bun /app/.next/standalone ./
-COPY --from=build --chown=bun:bun /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
 
 EXPOSE 3000
 ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
-CMD ["bun", "server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## チケットへのリンク

fix #35

## やったこと

- `typing-app/Dockerfile` を yarn 用に修正した
  - これによって失敗していた CI が回るはず！具体的な内容は issue 35 を見てください
- その他 `.dockerignore` に `.yarn` と `.dockerignore` を追加するなど

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 手元で `docker compose build -f compose.ci.yaml app` を何回か行って正常に動作することを確認した