### PR TITLE
ci: change docker compose -> podman-compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   deploy:
     name: Deploy
-    needs: build-and-push
     runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4
-      - name: docker compose up
+      - name: podman-compose up
         shell: bash
-        run: docker compose up -f compose.yml -d
+        run: docker-compose up -f compose.yml -d
+        working-directory: docker
         env:
           COMPOSE_PROJECT_NAME: typing


### PR DESCRIPTION
## やったこと

- デプロイ先のサーバで podman-compose コマンドを docker compose の代わりに使うことにした

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 未

## その他

podman-compose は podman と直にしゃべるっぽくてなんか docker-compose より軽そうな気がする

RHEL で docker 使うとなると、基本的に docker のふりをした podman がバックエンドにいるので podman に乗っかれるなら乗っかった方がいいのかなっていう判断(ふわっと)