### PR TITLE
ci: golangci-lint に on.push のパスを追加した

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    paths:
+      - "typing-server/**"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## やったこと

- golangci-lint のワークフローが回る条件が on.push to main / develop だったが、これに `pathes: typing-server/**` の条件を追加した

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し
## できなくなること（ユーザ目線）

- 無し
## 動作確認

- 未検証
