### PR TITLE
feat[typing-app]: バックエンドAPIを呼ぶクライアントを作成

### DIFF
--- a/typing-app/docs/api-usage.md
+++ b/typing-app/docs/api-usage.md
@@ -6,8 +6,22 @@
 
 例えば、
 
-```ts
-// WIP
+```tsx
+import { client } from "@/libs/api";
+
+async function SomePageToGetRanking() {
+  const { data, error } = await client.GET("/scores/ranking");
+
+  if (error) {
+    return <div>Error</div>;
+  }
+
+  return (
+    <div>
+      ranking data: {JSON.stringify(data)}
+    </div>
+  );
+}
 ```
 
 のようにします。

--- a/typing-app/src/libs/api/index.ts
+++ b/typing-app/src/libs/api/index.ts
@@ -1,0 +1,4 @@
+import createClient from "openapi-fetch";
+import { paths } from "./v1";
+
+export const client = createClient<paths>({ baseUrl: process.env.API_URL });


### PR DESCRIPTION
## やったこと

- バックエンド API を呼び出すコードを書いた ( #24 の続きといえば続きです)

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 開発者目線では `client.GET("/healthcheck")`とするとヘルスチェック API を呼び出せるようになった

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

RankingPageを下記のように書き換えて http://localhost:3000/ranking にアクセス。想定通り next.js サーバーから API にリクエストが飛んだこと。それと同時にブラウザからはAPIリクエストが飛ばなかったことを確認した。
```diff
-import RankingPage from "@/components/pages/Ranking";
+// import RankingPage from "@/components/pages/Ranking";
+import { client } from "@/libs/api";
 
-export default function Ranking() {
-  return <RankingPage />;
+export default async function Ranking() {
+  const { data, error } = await client.GET("/scores/ranking");
+
+  if (error) {
+    return <div>Error</div>;
+  }
+
+  return (
+    <div>
+      ranking data: {JSON.stringify(data)}
+    </div>
+  );
+  // return <RankingPage />;
 }
```
![image](https://github.com/su-its/typing/assets/61489178/8a0a3f9b-1098-41fb-b931-647d1bdfc56c)