### PR TITLE
feat: リザルト画面で「ゲームを終了する」ボタンの追加

### DIFF
--- a/typing-app/src/components/templates/GameResult.tsx
+++ b/typing-app/src/components/templates/GameResult.tsx
@@ -14,7 +14,7 @@ const GameResult: React.FC<GameResultProps> = ({ nextPage, resultScore }) => {
 
   const pushToRoot = () => {
     router.push("/");
-  }
+  };
 
   return (
     <div className={styles.box}>

--- a/typing-app/src/components/templates/GameResult.tsx
+++ b/typing-app/src/components/templates/GameResult.tsx
@@ -86,9 +86,14 @@ const GameResult: React.FC<GameResultProps> = ({ nextPage, resultScore }) => {
             {resultScore.accuracy.toFixed(1)}%
           </Text>
         </GridItem>
-        <GridItem colSpan={4} rowSpan={2} colStart={4} rowStart={9} className={styles.centerText}>
-          <Button onClick={nextPage} colorScheme="blue" size="lg" w="100%" h="90%">
-            次へ
+        <GridItem colSpan={4} rowSpan={2} colStart={2} rowStart={9} className={styles.centerText}>
+          <Button onClick={nextPage} colorScheme="red" size="lg" w="80%" h="90%">
+            ゲームを終了する
+          </Button>
+        </GridItem>
+        <GridItem colSpan={4} rowSpan={2} colStart={6} rowStart={9} className={styles.centerText}>
+          <Button onClick={nextPage} colorScheme="blue" size="lg" w="80%" h="90%">
+            もう一度プレイする
           </Button>
         </GridItem>
       </Grid>

--- a/typing-app/src/components/templates/GameResult.tsx
+++ b/typing-app/src/components/templates/GameResult.tsx
@@ -87,7 +87,7 @@ const GameResult: React.FC<GameResultProps> = ({ nextPage, resultScore }) => {
           </Text>
         </GridItem>
         <GridItem colSpan={4} rowSpan={2} colStart={2} rowStart={9} className={styles.centerText}>
-          <Button onClick={nextPage} colorScheme="red" size="lg" w="80%" h="90%">
+          <Button onClick={() => window.location.href = '/'} colorScheme="red" size="lg" w="80%" h="90%">
             ゲームを終了する
           </Button>
         </GridItem>

--- a/typing-app/src/components/templates/GameResult.tsx
+++ b/typing-app/src/components/templates/GameResult.tsx
@@ -2,6 +2,7 @@ import { ResultScore } from "@/types/RegisterScore";
 import { Button, Grid, GridItem, Text } from "@chakra-ui/react";
 import React from "react";
 import styles from "./GameResult.module.css";
+import { useRouter } from "next/navigation";
 
 interface GameResultProps {
   nextPage: () => void;
@@ -9,6 +10,12 @@ interface GameResultProps {
 }
 
 const GameResult: React.FC<GameResultProps> = ({ nextPage, resultScore }) => {
+  const router = useRouter();
+
+  const pushToRoot = () => {
+    router.push("/");
+  }
+
   return (
     <div className={styles.box}>
       <Grid h="100%" w="100%" templateRows="repeat(10, 1fr)" templateColumns="repeat(10, 1fr)" gap={6} bg="white">
@@ -87,7 +94,7 @@ const GameResult: React.FC<GameResultProps> = ({ nextPage, resultScore }) => {
           </Text>
         </GridItem>
         <GridItem colSpan={4} rowSpan={2} colStart={2} rowStart={9} className={styles.centerText}>
-          <Button onClick={() => window.location.href = '/'} colorScheme="red" size="lg" w="80%" h="90%">
+          <Button onClick={pushToRoot} colorScheme="red" size="lg" w="80%" h="90%">
             ゲームを終了する
           </Button>
         </GridItem>


### PR DESCRIPTION
## やったこと

- リザルト画面において，「次へ」ボタンを「もう一度プレイする」ボタンに名前を変更
- 「ゲームを終了する」ボタンを追加した

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- リザルト画面において，「ゲームを終了する」ボタンか「もう一度プレイする」ボタンかどちらかを選択することができる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- yarn buildが通ることを確認
```
yarn build
   ▲ Next.js 14.1.0
   - Environments: .env

   Creating an optimized production build ...
 ⚠ For production Image Optimization with Next.js, the optional 'sharp' package is strongly recommended. Run 'npm i sharp', and Next.js will use it automatically for Image Optimization.
Read more: https://nextjs.org/docs/messages/sharp-missing-in-production
Compiler server unexpectedly exited with code: null and signal: SIGTERM
 ⚠ For production Image Optimization with Next.js, the optional 'sharp' package is strongly recommended. Run 'npm i sharp', and Next.js will use it automatically for Image Optimization.
Read more: https://nextjs.org/docs/messages/sharp-missing-in-production
Compiler client unexpectedly exited with code: null and signal: SIGTERM
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    1.55 kB         258 kB
├ ○ /_not-found                          882 B          85.2 kB
├ ○ /game                                9.37 kB         139 kB
└ ○ /ranking                             1.68 kB         137 kB
+ First Load JS shared by all            84.3 kB
  ├ chunks/69-684208d8427a30a4.js        28.9 kB
  ├ chunks/fd9d1056-780053702ed842a5.js  53.4 kB
  └ other shared chunks (total)          2.04 kB


○  (Static)  prerendered as static content
```

