### PR TITLE
UserCardでAPIから取得したデータを使用

### DIFF
--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -1,0 +1,36 @@
+import { UserCardPresenter  } from "@/components/molecules/UserCard";
+import { describe, expect, it } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+
+describe("UserCard", () => {
+    const mockUser = {
+        handleName: "しずっぴー",
+        studentNumber: "B1234567",
+        id: "1",
+    };
+
+    it("renders UserCard", () => {
+        const userCard = render(<UserCardPresenter user={mockUser} />);
+
+        const avatar = screen.getByRole("img");
+        expect(avatar).toBeInTheDocument();
+    });
+
+    it("renders UserCard with user data", () => {
+        const userCard = render(<UserCardPresenter user={mockUser} />);
+
+        const name = screen.getByText(/名前:/);
+        const studentNumber = screen.getByText(/学籍番号:/);
+        expect(name).toHaveTextContent(mockUser.handleName);
+        expect(studentNumber).toHaveTextContent(mockUser.studentNumber);
+    });
+
+    it("renders UserCard with default data", () => {
+        const userCard = render(<UserCardPresenter user={null} />);
+
+        const name = screen.getByText(/名前:/);
+        const studentNumber = screen.getByText(/学籍番号:/);
+        expect(name).toHaveTextContent("ログインしていません");
+        expect(studentNumber).toHaveTextContent("未ログイン");
+    });
+});

--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -1,7 +1,7 @@
 import { UserCardPresenter } from "@/components/molecules/UserCard";
 import { describe, expect, it } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
-import { User } from "@/types/user";
+import type { User } from "@/types/user";
 
 describe("UserCard", () => {
   const mockUser: User = {

--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -27,7 +27,7 @@ describe("UserCard", () => {
   });
 
   it("renders UserCard with default data", () => {
-    const userCard = render(<UserCardPresenter user={ null as any } />);
+    const userCard = render(<UserCardPresenter user={null as any} />);
 
     const name = screen.getByText(/名前:/);
     const studentNumber = screen.getByText(/学籍番号:/);

--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -1,23 +1,24 @@
 import { UserCardPresenter } from "@/components/molecules/UserCard";
 import { describe, expect, it } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
+import { User } from "@/types/user";
 
 describe("UserCard", () => {
-  const mockUser = {
+  const mockUser: User = {
     handleName: "しずっぴー",
     studentNumber: "B1234567",
     id: "1",
   };
 
   it("renders UserCard", () => {
-    const userCard = render(<UserCardPresenter user={mockUser} />);
+    const userCard = render(UserCardPresenter(mockUser));
 
     const avatar = screen.getByRole("img");
     expect(avatar).toBeInTheDocument();
   });
 
   it("renders UserCard with user data", () => {
-    const userCard = render(<UserCardPresenter user={mockUser} />);
+    const userCard = render(UserCardPresenter(mockUser));
 
     const name = screen.getByText(/名前:/);
     const studentNumber = screen.getByText(/学籍番号:/);
@@ -26,7 +27,7 @@ describe("UserCard", () => {
   });
 
   it("renders UserCard with default data", () => {
-    const userCard = render(<UserCardPresenter user={null} />);
+    const userCard = render(UserCardPresenter(null));
 
     const name = screen.getByText(/名前:/);
     const studentNumber = screen.getByText(/学籍番号:/);

--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -1,36 +1,36 @@
-import { UserCardPresenter  } from "@/components/molecules/UserCard";
+import { UserCardPresenter } from "@/components/molecules/UserCard";
 import { describe, expect, it } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
 
 describe("UserCard", () => {
-    const mockUser = {
-        handleName: "しずっぴー",
-        studentNumber: "B1234567",
-        id: "1",
-    };
+  const mockUser = {
+    handleName: "しずっぴー",
+    studentNumber: "B1234567",
+    id: "1",
+  };
 
-    it("renders UserCard", () => {
-        const userCard = render(<UserCardPresenter user={mockUser} />);
+  it("renders UserCard", () => {
+    const userCard = render(<UserCardPresenter user={mockUser} />);
 
-        const avatar = screen.getByRole("img");
-        expect(avatar).toBeInTheDocument();
-    });
+    const avatar = screen.getByRole("img");
+    expect(avatar).toBeInTheDocument();
+  });
 
-    it("renders UserCard with user data", () => {
-        const userCard = render(<UserCardPresenter user={mockUser} />);
+  it("renders UserCard with user data", () => {
+    const userCard = render(<UserCardPresenter user={mockUser} />);
 
-        const name = screen.getByText(/名前:/);
-        const studentNumber = screen.getByText(/学籍番号:/);
-        expect(name).toHaveTextContent(mockUser.handleName);
-        expect(studentNumber).toHaveTextContent(mockUser.studentNumber);
-    });
+    const name = screen.getByText(/名前:/);
+    const studentNumber = screen.getByText(/学籍番号:/);
+    expect(name).toHaveTextContent(mockUser.handleName);
+    expect(studentNumber).toHaveTextContent(mockUser.studentNumber);
+  });
 
-    it("renders UserCard with default data", () => {
-        const userCard = render(<UserCardPresenter user={null} />);
+  it("renders UserCard with default data", () => {
+    const userCard = render(<UserCardPresenter user={null} />);
 
-        const name = screen.getByText(/名前:/);
-        const studentNumber = screen.getByText(/学籍番号:/);
-        expect(name).toHaveTextContent("ログインしていません");
-        expect(studentNumber).toHaveTextContent("未ログイン");
-    });
+    const name = screen.getByText(/名前:/);
+    const studentNumber = screen.getByText(/学籍番号:/);
+    expect(name).toHaveTextContent("ログインしていません");
+    expect(studentNumber).toHaveTextContent("未ログイン");
+  });
 });

--- a/typing-app/__test__/components/UserCard.test.tsx
+++ b/typing-app/__test__/components/UserCard.test.tsx
@@ -11,14 +11,14 @@ describe("UserCard", () => {
   };
 
   it("renders UserCard", () => {
-    const userCard = render(UserCardPresenter(mockUser));
+    const userCard = render(<UserCardPresenter user={mockUser} />);
 
     const avatar = screen.getByRole("img");
     expect(avatar).toBeInTheDocument();
   });
 
   it("renders UserCard with user data", () => {
-    const userCard = render(UserCardPresenter(mockUser));
+    const userCard = render(<UserCardPresenter user={mockUser} />);
 
     const name = screen.getByText(/名前:/);
     const studentNumber = screen.getByText(/学籍番号:/);
@@ -27,7 +27,7 @@ describe("UserCard", () => {
   });
 
   it("renders UserCard with default data", () => {
-    const userCard = render(UserCardPresenter(null));
+    const userCard = render(<UserCardPresenter user={ null as any } />);
 
     const name = screen.getByText(/名前:/);
     const studentNumber = screen.getByText(/学籍番号:/);

--- a/typing-app/src/app/actions.ts
+++ b/typing-app/src/app/actions.ts
@@ -45,12 +45,12 @@ export async function logout() {
 
 export async function getCurrentUser() {
   const userStr = cookies().get("user")?.value;
-  if (!userStr) return null;
+  if (!userStr) return undefined;
 
   function isValidUser(o: any): o is User {
     return o && typeof o.id === "string" && typeof o.studentNumber === "string" && typeof o.handleName == "string";
   }
 
   const user = JSON.parse(userStr) as User;
-  return isValidUser(user) ? user : null;
+  return isValidUser(user) ? user : undefined;
 }

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -8,17 +8,17 @@ type UserCardProps = {
 
 export const UserCardPresenter: React.FC<UserCardProps> = ({ user }) => {
   return (
-      <Box bg="blue.600" p={5}>
-        <HStack spacing={4}>
-          <Avatar /*src={ TODO: しずっぴーを表示 }*/ maxW="100px" borderRadius="9" />
-          <VStack align="start">
-            <Text fontSize="lg" fontWeight="bold" color="white">
-              名前: {user ? user.handleName : "ログインしていません"}
-            </Text>
-            <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
-          </VStack>
-        </HStack>
-      </Box>
+    <Box bg="blue.600" p={5}>
+      <HStack spacing={4}>
+        <Avatar /*src={ TODO: しずっぴーを表示 }*/ maxW="100px" borderRadius="9" />
+        <VStack align="start">
+          <Text fontSize="lg" fontWeight="bold" color="white">
+            名前: {user ? user.handleName : "ログインしていません"}
+          </Text>
+          <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
+        </VStack>
+      </HStack>
+    </Box>
   );
 };
 

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,29 +1,30 @@
 import React from "react";
 import { Avatar, Box, Text, HStack, VStack } from "@chakra-ui/react";
+import { getCurrentUser } from "@/app/actions";
 
-const UserCard: React.FC = () => {
-  // モックのユーザー情報
-  const user = {
-    name: "テストユーザー",
-    studentId: "24AB1234",
-    avatarUrl: "https://avatars.githubusercontent.com/u/12345678?v=4",
-  };
+type UserCardProps = {
+  user: Awaited<ReturnType<typeof getCurrentUser>>;
+};
 
+export const UserCardPresenter: React.FC<UserCardProps> = ({ user }) => {
   return (
-    user && (
-      <Box bg={"blue.600"} p={5}>
+      <Box bg="blue.600" p={5}>
         <HStack spacing={4}>
-          <Avatar src={user.avatarUrl} maxW="100px" borderRadius="9" />
+          <Avatar /*src={ TODO: しずっぴーを表示 }*/ maxW="100px" borderRadius="9" />
           <VStack align="start">
-            <Text fontSize="lg" fontWeight="bold" color={"white"}>
-              名前: {user.name}
+            <Text fontSize="lg" fontWeight="bold" color="white">
+              名前: {user ? user.handleName : "ログインしていません"}
             </Text>
-            <Text color={"white"}>学籍番号: {user.studentId}</Text>
+            <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
           </VStack>
         </HStack>
       </Box>
-    )
   );
+};
+
+const UserCard = async () => {
+  const user = await getCurrentUser();
+  return <UserCardPresenter user={user} />;
 };
 
 export default UserCard;

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -9,17 +9,15 @@ interface UserCardPresenterProps {
 
 export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   return (
-    <Box bg="blue.600" p={5}>
-      <HStack spacing={4}>
-        <Avatar src={ "https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png" } maxW="100px" borderRadius="0" />
-        <VStack align="start">
-          <Text fontSize="lg" fontWeight="bold" color="white">
-            名前: {user ? user.handleName : "ログインしていません"}
-          </Text>
-          <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
-        </VStack>
-      </HStack>
-    </Box>
+    <HStack spacing={4} bg="blue.600">
+      <Avatar src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"} boxSize="100px" borderRadius="0" />
+      <VStack align="start" paddingRight="8px">
+        <Text fontSize="lg" fontWeight="bold" color="white">
+          名前: {user ? user.handleName : "ログインしていません"}
+        </Text>
+        <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
+      </VStack>
+    </HStack>
   );
 };
 

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -11,7 +11,7 @@ export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   return (
     <Box bg="blue.600" p={5}>
       <HStack spacing={4}>
-        <Avatar /*src={ TODO: しずっぴーを表示 }*/ maxW="100px" borderRadius="9" />
+        <Avatar src={ "https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png" } maxW="100px" borderRadius="0" />
         <VStack align="start">
           <Text fontSize="lg" fontWeight="bold" color="white">
             名前: {user ? user.handleName : "ログインしていません"}

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -10,7 +10,11 @@ interface UserCardPresenterProps {
 export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   return (
     <HStack spacing={4} bg="blue.600">
-      <Avatar src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"} boxSize="100px" borderRadius="0" />
+      <Avatar
+        src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"}
+        boxSize="100px"
+        borderRadius="0"
+      />
       <VStack align="start" paddingRight="8px">
         <Text fontSize="lg" fontWeight="bold" color="white">
           名前: {user ? user.handleName : "ログインしていません"}

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { Avatar, Box, Text, HStack, VStack } from "@chakra-ui/react";
 import { getCurrentUser } from "@/app/actions";
+import { User } from "@/types/user";
 
-type UserCardProps = {
-  user: Awaited<ReturnType<typeof getCurrentUser>>;
-};
-
-export const UserCardPresenter: React.FC<UserCardProps> = ({ user }) => {
+export async function UserCardPresenter(user: User | null) {
   return (
     <Box bg="blue.600" p={5}>
       <HStack spacing={4}>
@@ -20,11 +17,11 @@ export const UserCardPresenter: React.FC<UserCardProps> = ({ user }) => {
       </HStack>
     </Box>
   );
-};
+}
 
 const UserCard = async () => {
   const user = await getCurrentUser();
-  return <UserCardPresenter user={user} />;
+  return UserCardPresenter(user);
 };
 
 export default UserCard;

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -7,7 +7,7 @@ interface UserCardPresenterProps {
   user?: User;
 }
 
-export const UserCardPresenter = ({ user }:UserCardPresenterProps) => {
+export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   return (
     <Box bg="blue.600" p={5}>
       <HStack spacing={4}>
@@ -21,11 +21,11 @@ export const UserCardPresenter = ({ user }:UserCardPresenterProps) => {
       </HStack>
     </Box>
   );
-}
+};
 
 const UserCard = async () => {
   const user = await getCurrentUser();
-  return <UserCardPresenter user={user}/>;
+  return <UserCardPresenter user={user} />;
 };
 
 export default UserCard;

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import { Avatar, Box, Text, HStack, VStack } from "@chakra-ui/react";
 import { getCurrentUser } from "@/app/actions";
-import { User } from "@/types/user";
+import type { User } from "@/types/user";
 
-export async function UserCardPresenter(user: User | null) {
+interface UserCardPresenterProps {
+  user?: User;
+}
+
+export const UserCardPresenter = ({ user }:UserCardPresenterProps) => {
   return (
     <Box bg="blue.600" p={5}>
       <HStack spacing={4}>
@@ -21,7 +25,7 @@ export async function UserCardPresenter(user: User | null) {
 
 const UserCard = async () => {
   const user = await getCurrentUser();
-  return UserCardPresenter(user);
+  return <UserCardPresenter user={user}/>;
 };
 
 export default UserCard;


### PR DESCRIPTION
## チケットへのリンク
resolve https://github.com/su-its/typing/issues/67
## やったこと
UserCardで表示するデータをAPIから取得したものに変更
テストの実装
## やらないこと
なし
## できるようになること（ユーザ目線）
ログインするとユーザーカードに情報が表示されるようになる
## できなくなること（ユーザ目線）
なし
## 動作確認
ローカル環境で確認
## その他
しずっぴーのいい画像があればこのブランチでつけます