### PR TITLE
Docs/openapi ranking endpoints

### DIFF
--- a/typing-app/src/libs/api/v1.d.ts
+++ b/typing-app/src/libs/api/v1.d.ts
@@ -114,9 +114,9 @@ export interface operations {
       200: {
         content: {
           "application/json": {
-            rankings?: components["schemas"]["ScoreRanking"][];
+            rankings: components["schemas"]["ScoreRanking"][];
             /** @description ランキングの全件数 */
-            total_count?: number;
+            total_count: number;
           };
         };
       };
@@ -171,7 +171,7 @@ export interface operations {
         content: {
           "application/json": {
             /** @description ユーザーの現在の順位 */
-            "current-rank"?: number;
+            "current-rank": number;
           };
         };
       };

--- a/typing-server/openapi.yaml
+++ b/typing-server/openapi.yaml
@@ -88,6 +88,9 @@ paths:
                   total_count:
                     type: integer
                     description: ランキングの全件数
+                required: 
+                - rankings
+                - total_count
         "400":
           description: 不正なリクエストです。
 
@@ -150,6 +153,8 @@ paths:
                   current-rank:
                     type: integer
                     description: ユーザーの現在の順位
+                required:  
+                  - current-rank
         "404":
           description: ユーザーが見つかりません。
         "500":

--- a/typing-server/openapi.yaml
+++ b/typing-server/openapi.yaml
@@ -119,6 +119,36 @@ paths:
         "400":
           description: 不正なリクエストです。
 
+  /scores/{user-id}/current-rank:
+    get:
+      tags:
+        - user
+      operationId: getMyscoreRanking
+      summary: ユーザーの現在の順位を取得
+      parameters:
+        - in: path
+          name: user-id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: ユーザーID
+      responses:
+        "200":
+          description: ユーザーの現在の順位を返します。
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  current-rank:
+                    type: integer
+                    description: ユーザーの現在の順位
+        "404":
+          description: ユーザーが見つかりません。
+        "500":
+          description: サーバーエラーが発生しました。
+
 components:
   schemas:
     User:

--- a/typing-server/openapi.yaml
+++ b/typing-server/openapi.yaml
@@ -89,8 +89,8 @@ paths:
                     type: integer
                     description: ランキングの全件数
                 required: 
-                - rankings
-                - total_count
+                  - rankings
+                  - total_count
         "400":
           description: 不正なリクエストです。
 

--- a/typing-server/openapi.yaml
+++ b/typing-server/openapi.yaml
@@ -79,9 +79,15 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ScoreRanking"
+                type: object 
+                properties:
+                  rankings:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ScoreRanking"
+                  total_count:
+                    type: integer
+                    description: ランキングの全件数
         "400":
           description: 不正なリクエストです。
 


### PR DESCRIPTION
## チケットへのリンク



## やったこと

-openapiのドキュメントの変更
→1．  /scores/{user-id}/current-rank:の追加．ユーザーが自分の順位を確認できる機能を追加するために順位を返す
2．  /scores/ranking:のレスポンスにランキングの全件数をを追加．何ページまで結果を表示できるかを考慮するためにレスポンスにランキングの全件数を含めました

## やらないこと

- 実際にハンドラー等の実装歯行いません

## できるようになること（ユーザ目線）

- なし．開発者はビュワーで確認できます

## できなくなること（ユーザ目線）

-特になし

## 動作確認

-現状は実装に変更がないため確認はできない？ビュワーで存在は確認した

## その他

- パスはアンダースコアじゃなくてハイフンでつなぐのが良いらしい
