### PR TITLE
Fix/header/usercard width

### DIFF
--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,15 +1,21 @@
 import React from "react";
 import { Avatar, Text, HStack, VStack, Spacer } from "@chakra-ui/react";
+import type { StackProps } from "@chakra-ui/react";
 import { getCurrentUser } from "@/app/actions";
 import type { User } from "@/types/user";
 
-interface UserCardPresenterProps {
+interface UserCardPresenterProps extends StackProps {
   user?: User;
 }
 
-export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
+export const UserCardPresenter = ({ user, ...rest }: UserCardPresenterProps) => {
+  const props: StackProps = {
+    width: rest?.width ?? "18%",
+    ...rest,
+  };
+
   return (
-    <HStack spacing={4} bg="blue.600" width="18%">
+    <HStack spacing={4} bg="blue.600" {...props}>
       <Avatar
         src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"}
         boxSize="100px"
@@ -28,9 +34,9 @@ export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   );
 };
 
-const UserCard = async () => {
+const UserCard = async (props?: StackProps) => {
   const user = await getCurrentUser();
-  return <UserCardPresenter user={user} />;
+  return <UserCardPresenter user={user} {...props} />;
 };
 
 export default UserCard;

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -20,7 +20,9 @@ export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
         <Text fontSize="lg" fontWeight="bold" color="white" isTruncated width="90%">
           名前: {user ? user.handleName : "ログインしていませんaaaaaaaaa"}
         </Text>
-        <Text color="white" width="90%" isTruncated>学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
+        <Text color="white" width="90%" isTruncated>
+          学籍番号: {user ? user.studentNumber : "未ログイン"}
+        </Text>
       </VStack>
     </HStack>
   );

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Avatar, Box, Text, HStack, VStack } from "@chakra-ui/react";
+import { Avatar, Box, Text, HStack, VStack, Spacer } from "@chakra-ui/react";
 import { getCurrentUser } from "@/app/actions";
 import type { User } from "@/types/user";
 
@@ -9,17 +9,18 @@ interface UserCardPresenterProps {
 
 export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
   return (
-    <HStack spacing={4} bg="blue.600">
+    <HStack spacing={4} bg="blue.600" width="18%">
       <Avatar
         src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"}
         boxSize="100px"
         borderRadius="0"
       />
-      <VStack align="start" paddingRight="8px">
-        <Text fontSize="lg" fontWeight="bold" color="white">
-          名前: {user ? user.handleName : "ログインしていません"}
+      <Spacer />
+      <VStack align="start" width="full" justifyContent="center">
+        <Text fontSize="lg" fontWeight="bold" color="white" isTruncated width="90%">
+          名前: {user ? user.handleName : "ログインしていませんaaaaaaaaa"}
         </Text>
-        <Text color="white">学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
+        <Text color="white" width="90%" isTruncated>学籍番号: {user ? user.studentNumber : "未ログイン"}</Text>
       </VStack>
     </HStack>
   );

--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Avatar, Box, Text, HStack, VStack, Spacer } from "@chakra-ui/react";
+import { Avatar, Text, HStack, VStack, Spacer } from "@chakra-ui/react";
 import { getCurrentUser } from "@/app/actions";
 import type { User } from "@/types/user";
 
@@ -16,9 +16,9 @@ export const UserCardPresenter = ({ user }: UserCardPresenterProps) => {
         borderRadius="0"
       />
       <Spacer />
-      <VStack align="start" width="full" justifyContent="center">
+      <VStack align="start" overflow="hidden">
         <Text fontSize="lg" fontWeight="bold" color="white" isTruncated width="90%">
-          名前: {user ? user.handleName : "ログインしていませんaaaaaaaaa"}
+          名前: {user ? user.handleName : "ログインしていません"}
         </Text>
         <Text color="white" width="90%" isTruncated>
           学籍番号: {user ? user.studentNumber : "未ログイン"}

--- a/typing-app/src/components/organism/Header.tsx
+++ b/typing-app/src/components/organism/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC = () => {
     <>
       <Flex alignItems="center" justifyContent="space-between">
         <Banner />
-        <UserCard />
+        <UserCard width="300px" />
       </Flex>
       <Separator />
     </>


### PR DESCRIPTION
## チケットへのリンク
resolve https://github.com/su-its/typing/issues/101
## やったこと
UserCardの幅を固定
## やらないこと
なし
## できるようになること（ユーザ目線）
長いユーザー名を使ってもスタイルが崩れなくなる 
## 動作確認
ローカルで確認