### PR TITLE
fix: 長文が BOX からはみ出るのを修正

### DIFF
--- a/typing-app/src/components/templates/GameTyping.module.css
+++ b/typing-app/src/components/templates/GameTyping.module.css
@@ -125,6 +125,8 @@
   font-size: 24px;
   line-height: 48px;
   color: #fff;
+  height: 100%;
+  overflow-y: hidden;
 }
 
 .span_typed_text {


### PR DESCRIPTION
## チケットへのリンク

- #97

## やったこと

- 長文が BOX からはみ出ないようにした

## やらないこと

- 自動でスクロールしたり現在のカーソル位置が順次上がっていったりはしない

## できるようになること（ユーザ目線）

- 長文が BOX からはみ出ないようになる

## できなくなること（ユーザ目線）

- 無し

## 動作確認
![image](https://github.com/su-its/typing/assets/61489178/cb85a4da-ec34-4075-ade6-3ce2f9acd9b4)


## その他

お疲れのところとは思いますが、あと少しよろしくお願いします！ :bow: