### PR TITLE
/gameに直接アクセスした際にログイン状況をチェック

### DIFF
--- a/typing-app/src/components/pages/Game.tsx
+++ b/typing-app/src/components/pages/Game.tsx
@@ -1,10 +1,14 @@
 "use client";
 import { ResultScore } from "@/types/RegisterScore";
 import { VStack } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import GamePre from "../templates/GamePre";
 import GameResult from "../templates/GameResult";
 import GameTyping from "../templates/GameTyping";
+import { useRouter } from "next/navigation";
+import { showWarningToast } from "@/utils/toast";
+import { User } from "@/types/user";
+import { getCurrentUser } from "@/app/actions";
 
 export interface GamePreProps {
   nextPage: () => void;
@@ -22,6 +26,22 @@ interface GamePageProps {
 }
 
 const GamePage: React.FC<GamePageProps> = ({ subjectText }) => {
+  //ログインしていなければ、トップページにリダイレクト
+  const router = useRouter();
+  const isUserLoggedIn = async () => {
+    const user: User | undefined = await getCurrentUser();
+    return user;
+  }  
+
+  useEffect(() => {
+    isUserLoggedIn().then((user) => {
+      if (!user) {
+        showWarningToast("ログインしてください");
+        router.push("/");
+      }
+    });
+  }, []);  
+
   const ScreenIndex = {
     IDX_PRE: 0,
     IDX_TYPING: 1,

--- a/typing-app/src/components/pages/Game.tsx
+++ b/typing-app/src/components/pages/Game.tsx
@@ -31,7 +31,7 @@ const GamePage: React.FC<GamePageProps> = ({ subjectText }) => {
   const isUserLoggedIn = async () => {
     const user: User | undefined = await getCurrentUser();
     return user;
-  }  
+  };
 
   useEffect(() => {
     isUserLoggedIn().then((user) => {
@@ -40,7 +40,7 @@ const GamePage: React.FC<GamePageProps> = ({ subjectText }) => {
         router.push("/");
       }
     });
-  }, []);  
+  }, []);
 
   const ScreenIndex = {
     IDX_PRE: 0,


### PR DESCRIPTION
## チケットへのリンク
resolve #105 
## やったこと
`/game`に直接アクセスした際に、ログイン状況をチェックしてログインしていなければ`/`にpush
## やらないこと
なし
## できるようになること（ユーザ目線）
なし
## できなくなること（ユーザ目線）
ログインしていない状況での`/game`へのアクセス
## 動作確認
ローカルで確認
## その他
`yarn dev`環境で実行すると、`strict mode`の影響によりtoastが二回出ます。