### PR TITLE
Fix/frontend/limit avarage speed

### DIFF
--- a/typing-app/src/components/templates/GameTyping.tsx
+++ b/typing-app/src/components/templates/GameTyping.tsx
@@ -17,7 +17,7 @@ import { useRouter } from "next/navigation";
 const GameTyping: React.FC<GameTypingProps> = ({ nextPage, subjectText, setResultScore }) => {
   const router = useRouter();
 
-  const [startedAt, setStartedAt] = useState(new Date());
+  const [startedAt, _] = useState(new Date());
 
   const totalSeconds = 60; // TODO: Configファイルから取得
   const [count, setCount] = useState(totalSeconds);

--- a/typing-app/src/components/templates/GameTyping.tsx
+++ b/typing-app/src/components/templates/GameTyping.tsx
@@ -106,7 +106,7 @@ const GameTyping: React.FC<GameTypingProps> = ({ nextPage, subjectText, setResul
   useEffect(() => {
     const calcAverageTypingSpeed = (): number => {
       const timeFromStart: number = new Date().valueOf() - startedAt.valueOf();
-      const averageTypingSpeed: number = (correctType / timeFromStart) * 60000;
+      const averageTypingSpeed: number = Math.min((correctType / timeFromStart) * 60000, 300); // 300 で頭打ち
       return averageTypingSpeed;
     };
 


### PR DESCRIPTION
## チケットへのリンク

- fix #126

## やったこと

- ゲージの最大値を 300 にした
- 使ってない setStartedAt を消す

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- next build した。WPM 300 超えを出せなかったので動作確認できてないです