### PR TITLE
UserCard の横幅を文字が切れない程度に広くする

### DIFF
--- a/typing-app/src/components/molecules/UserCard.tsx
+++ b/typing-app/src/components/molecules/UserCard.tsx
@@ -18,11 +18,10 @@ export const UserCardPresenter = ({ user, ...rest }: UserCardPresenterProps) => 
     <HStack spacing={4} bg="blue.600" {...props}>
       <Avatar
         src={"https://www.shizuoka.ac.jp/cms/files/shizudai/MASTER/0100/uISrbYCb_VL033_r03.png"}
-        boxSize="100px"
+        boxSize="70px"
         borderRadius="0"
       />
-      <Spacer />
-      <VStack align="start" overflow="hidden">
+      <VStack align="start" overflow="hidden" flexGrow={1} gap={0}>
         <Text fontSize="lg" fontWeight="bold" color="white" isTruncated width="90%">
           名前: {user ? user.handleName : "ログインしていません"}
         </Text>

--- a/typing-app/src/components/organism/Header.tsx
+++ b/typing-app/src/components/organism/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Flex } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 // import { useAuth } from "@/hooks/useAuth";　// TODO: 実装
 import Banner from "@/components/atoms/Banner";
 import UserCard from "@/components/molecules/UserCard";
@@ -10,7 +10,7 @@ const Header: React.FC = () => {
     <>
       <Flex alignItems="center" justifyContent="space-between" bg="gray.800">
         <Banner />
-        <UserCard width="300px" />
+        <UserCard width="360px" />
       </Flex>
       <Separator />
     </>


### PR DESCRIPTION
## やったこと

- UserCard コンポーネントの横幅をタイトルの文字が切れない程度に広めに設定して Header から呼ぶように変更する
- UserCard コンポーネント自体も少し高さを低くする

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- (おそらく)フッターが見切れる症状がなくなる
  - 拡大率125%のモニタでフッターが見切れなくなることを確認しました

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- next build OK
![image](https://github.com/su-its/typing/assets/61489178/c7f832a5-aaa0-41ee-bbd6-7973b9587d42)
