### PR TITLE
スコアが登録されていない時に空の配列を返すように修正

### DIFF
--- a/typing-server/api/repository/score.go
+++ b/typing-server/api/repository/score.go
@@ -45,9 +45,13 @@ func GetScoresRanking(ctx context.Context, client *ent.Client, request *model.Ge
 		All(ctx)
 
 	if err != nil {
-		if !ent.IsNotFound(err) {
-			return nil, err
+		if ent.IsNotFound(err) {
+			return &model.GetScoresRankingResponse{
+				Rankings:   make([]*model.ScoreRanking, 0),
+				TotalCount: 0,
+			}, nil
 		}
+		return nil, err
 	}
 
 	rankings := make([]*model.ScoreRanking, 0, len(scores))


### PR DESCRIPTION
## チケットへのリンク

resolve https://github.com/su-its/typing/issues/130
resolve https://github.com/su-its/typing/issues/132

## やったこと

- スコアの登録時にレスポンスが500になるときがある
- ランキングが登録されていない時に空配列を返すように仕様に沿って修正

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
