### PR TITLE
feat: ユーザー追加のためのリポジトリを定義，作成

### DIFF
--- a/typing-server/internal/domain/model/model.go
+++ b/typing-server/internal/domain/model/model.go
@@ -9,6 +9,7 @@ type ScoreRanking struct {
 
 type User struct {
 	ID            string    `json:"id"`
+	// NOTE: 学籍番号はユニークであるべき．
 	StudentNumber string    `json:"student_number"`
 	HandleName    string    `json:"handle_name"`
 	CreatedAt     time.Time `json:"created_at"`
@@ -18,7 +19,9 @@ type User struct {
 type Score struct {
 	ID         string    `json:"id"`
 	UserID     string    `json:"user_id"`
+	// NOTE: キーストロークは正の値
 	Keystrokes int       `json:"keystrokes"`
+	// NOTE: 正確性は0.0から1.0の範囲であるべき．
 	Accuracy   float64   `json:"accuracy"`
 	CreatedAt  time.Time `json:"created_at"`
 	User       User      `json:"user"`

--- a/typing-server/internal/domain/repository/error.go
+++ b/typing-server/internal/domain/repository/error.go
@@ -3,5 +3,5 @@ package repository
 import "errors"
 
 var (
-	ErrAlreadyExists = errors.New("student number already exists")
+	ErrAlreadyExists = errors.New("user already exists")
 )

--- a/typing-server/internal/domain/repository/error.go
+++ b/typing-server/internal/domain/repository/error.go
@@ -1,0 +1,7 @@
+package repository
+
+import "errors"
+
+var (
+	ErrAlreadyExists = errors.New("student number already exists")
+)

--- a/typing-server/internal/domain/repository/user_repository.go
+++ b/typing-server/internal/domain/repository/user_repository.go
@@ -10,4 +10,7 @@ type UserRepository interface {
 	// GetUserByStudentNumber は、指定された学籍番号を持つユーザーを取得する。
 	// 該当するユーザーが存在しない場合は、(nil, nil) を返す。
 	GetUserByStudentNumber(ctx context.Context, studentNumber string) (*model.User, error)
+	// CreateUser は、指定された学籍番号とハンドルネームを持つユーザーを作成する。
+	// 既に同じ学籍番号を持つユーザーが存在する場合は、{nil, ErrAlreadyExists} を返す。
+	CreateUser(ctx context.Context, studentNumber string, handleName string) (*model.User, error)
 }

--- a/typing-server/internal/infra/ent/repository/ent_user_repository.go
+++ b/typing-server/internal/infra/ent/repository/ent_user_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"github.com/su-its/typing/typing-server/internal/domain/model"
 	"github.com/su-its/typing/typing-server/internal/domain/repository"
@@ -43,4 +44,8 @@ func (r *EntUserRepository) GetUserByStudentNumber(ctx context.Context, studentN
 		CreatedAt:     entUser.CreatedAt,
 		UpdatedAt:     entUser.UpdatedAt,
 	}, nil
+}
+
+func (r *EntUserRepository) CreateUser(ctx context.Context, studentNumber string, handleName string) (*model.User, error) {
+	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
## チケットへのリンク

- https://github.com/orgs/su-its/projects/example-hogehoge-fugafuga

## やったこと

- UserRepositoryにCreateUser functionを定義
- error.goに，学籍番号が重複した場合のエラーを定義
- EntUserRepositoryにCreateUser interfaceを作成

## やらないこと

- EntUserRepositoryにCreateUser interfaceを実装

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
