### PR TITLE
ci: Upgrade Docker Bake Action to v5

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: typing-app
         run: echo 'NEXT_PUBLIC_API_URL=${{ secrets.PROD_NEXT_PUBLIC_API_URL }}' >> .env.production
       - name: Docker Buildx Bake
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v5
         with:
           workdir: docker
           files: compose.ci.yaml


### PR DESCRIPTION
Why
Docker Image のPush回りのCIが落ちていた

What
Docker Bake Actionのバージョンをv5に上げた。

Details
こんなエラーが出ていたのでv5にした
Run docker/bake-action@v4
Error: docker/bake-action < v5 is not compatible with buildx >= 0.20.0, please update your workflow to latest docker/bake-action or use an older buildx version.

ref <https://github.com/su-its/typing/actions/runs/13560088353/job/37901504524#annotation:6:11>