### PR TITLE
ci: update the version of golang image to 1.23.4

### DIFF
--- a/docker/compose.ci.yaml
+++ b/docker/compose.ci.yaml
@@ -10,5 +10,5 @@ services:
     build:
       context: ../typing-server
       cache_from:
-        - golang:1.22.0
+        - golang:1.23.4
         - alpine:latest


### PR DESCRIPTION
## やったこと

- CIでイメージをビルドする際にキャッシュされるGoのイメージのバージョンを上げた
  - typing-server/Dockerfile 側のバージョンとずれていたため

## 動作確認

- ローカルではCACHEと表示が出てキャッシュが効いている(そのレイヤーのビルドがスキップされている)ことを確認しました
- これがマージされてCIを何度か回してやっと本当に動作確認できると思います

```bash
cd docker
docker --debug buildx bake --allow=fs.read=../typing-app --allow=fs.read=../typing-server -f compose.ci.yaml
```

<details><summary>docker buildx bakeの結果</summary>

```
projects/su-its-typing/docker  ci/docker/update-golang-1.23.4 [$+] ➜ docker --debug buildx bake --allow=fs.read=../typing-app --allow=fs.read=../typing-server -f compose.ci.yaml
[+] Building 8.7s (41/41) FINISHED                                                                       docker:default
 => [internal] load local bake definitions                                                                         0.0s
 => => reading compose.ci.yaml 302B / 302B                                                                         0.0s
 => [api internal] load build definition from Dockerfile                                                           0.1s
 => => transferring dockerfile: 753B                                                                               0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)                                     0.1s
 => [app internal] load build definition from Dockerfile                                                           0.1s
 => => transferring dockerfile: 653B                                                                               0.0s
 => [api internal] load metadata for docker.io/library/alpine:latest                                               0.0s
 => [api internal] load metadata for docker.io/library/golang:1.23.4                                               1.7s
 => [app] resolve image config for docker-image://docker.io/docker/dockerfile:1                                    1.8s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                   0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                      0.0s
 => [api internal] load .dockerignore                                                                              0.1s
 => => transferring context: 2B                                                                                    0.0s
 => CACHED [app] docker-image://docker.io/docker/dockerfile:1@sha256:4c68376a702446fc3c79af22de146a148bc3367e73c2  0.0s
 => [api] importing cache manifest from golang:1.23.4                                                              5.9s
 => => inferred cache manifest type: application/vnd.oci.image.index.v1+json                                       0.0s
 => [api] importing cache manifest from alpine:latest                                                              0.0s
 => [api builder 1/6] FROM docker.io/library/golang:1.23.4@sha256:9820aca42262f58451f006de3213055974b36f24b31508c  0.0s
 => [api stage-1 1/6] FROM docker.io/library/alpine:latest                                                         0.0s
 => [api internal] load build context                                                                              0.1s
 => => transferring context: 5.91kB                                                                                0.0s
 => [app internal] load metadata for docker.io/library/node:20.11-slim                                             0.0s
 => [app internal] load .dockerignore                                                                              0.1s
 => => transferring context: 94B                                                                                   0.0s
 => CACHED [api stage-1 2/6] RUN apk --no-cache add ca-certificates                                                0.0s
 => CACHED [api stage-1 3/6] RUN apk --no-cache add tzdata                                                         0.0s
 => CACHED [api stage-1 4/6] RUN apk --no-cache add curl                                                           0.0s
 => CACHED [api stage-1 5/6] WORKDIR /root                                                                         0.0s
 => CACHED [api builder 2/6] WORKDIR /app                                                                          0.0s
 => CACHED [api builder 3/6] COPY . .                                                                              0.0s
 => CACHED [api builder 4/6] RUN go mod download                                                                   0.0s
 => CACHED [api builder 5/6] RUN cd internal/infra/ent && go generate                                              0.0s
 => CACHED [api builder 6/6] RUN CGO_ENABLED=0 GOOS=linux go build -v -o server ./cmd/server/main.go               0.0s
 => CACHED [api stage-1 6/6] COPY --from=builder /app/server .                                                     0.0s
 => [api] exporting to image                                                                                       0.1s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:cfaec55ac5f4de8c112aa5e51125de4e5c87412d4c0afab7e22ff0c341903f5e                       0.0s
 => => naming to ghcr.io/su-its/typing-server:dev                                                                  0.0s
 => [app] importing cache manifest from node:20.11-slim                                                            0.0s
 => [app base 1/3] FROM docker.io/library/node:20.11-slim                                                          0.0s
 => [app internal] load build context                                                                              0.2s
 => => transferring context: 8.24kB                                                                                0.1s
 => CACHED [app base 2/3] WORKDIR /app                                                                             0.0s
 => CACHED [app base 3/3] RUN corepack enable yarn # to read "packageManager" in package.json                      0.0s
 => CACHED [app build 1/4] COPY package.json yarn.lock .yarnrc.yml ./                                              0.0s
 => CACHED [app build 2/4] RUN --mount=type=cache,target=/root/.cache/yarn/v6 yarn --immutable                     0.0s
 => CACHED [app build 3/4] COPY . .                                                                                0.0s
 => CACHED [app build 4/4] RUN yarn build                                                                          0.0s
 => CACHED [app final 1/3] COPY --from=build --chown=node:node /app/public ./public                                0.0s
 => CACHED [app final 2/3] COPY --from=build --chown=node:node /app/.next/standalone ./                            0.0s
 => CACHED [app final 3/3] COPY --from=build --chown=node:node /app/.next/static ./.next/static                    0.0s
 => [app] exporting to image                                                                                       0.1s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:180b72c10c93f78d403fe76649ddb071672f2e30bfe8aa3e7591b4feb491bd54                       0.0s
 => => naming to ghcr.io/su-its/typing-app:dev                                                                     0.0s

 7 warnings found:
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)
Legacy key/value format with whitespace separator should not be used
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
Dockerfile:22
--------------------
  20 |
  21 |     EXPOSE 3000
  22 | >>> ENV PORT 3000
  23 |     ENV HOSTNAME "0.0.0.0"
  24 |
--------------------

 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
Legacy key/value format with whitespace separator should not be used
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
Dockerfile:23
--------------------
  21 |     EXPOSE 3000
  22 |     ENV PORT 3000
  23 | >>> ENV HOSTNAME "0.0.0.0"
  24 |
  25 |     CMD ["node", "server.js"]
--------------------

 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:2
--------------------
   1 |     # 基本イメージ
   2 | >>> FROM golang:1.23.4 as builder
   3 |
   4 |     # 作業ディレクトリを設定
--------------------

 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:2
--------------------
   1 |     # syntax=docker/dockerfile:1
   2 | >>> FROM node:20.11-slim as base
   3 |     WORKDIR /app
   4 |     ENV NODE_ENV production
--------------------

 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 7)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:7
--------------------
   5 |     RUN corepack enable yarn # to read "packageManager" in package.json
   6 |
   7 | >>> FROM base as build
   8 |     COPY package.json yarn.lock .yarnrc.yml ./
   9 |     RUN --mount=type=cache,target=/root/.cache/yarn/v6 yarn --immutable
--------------------

 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 14)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:14
--------------------
  12 |     RUN yarn build
  13 |
  14 | >>> FROM base as final
  15 |     USER node
  16 |
--------------------

 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
Legacy key/value format with whitespace separator should not be used
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
Dockerfile:4
--------------------
   2 |     FROM node:20.11-slim as base
   3 |     WORKDIR /app
   4 | >>> ENV NODE_ENV production
   5 |     RUN corepack enable yarn # to read "packageManager" in package.json
   6 |
```

</details>

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
