### PR TITLE
build: fix dockerfile warning

### DIFF
--- a/typing-app/Dockerfile
+++ b/typing-app/Dockerfile
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1
-FROM node:20.11-slim as base
+FROM node:20.11-slim AS base
 WORKDIR /app
-ENV NODE_ENV production
+ENV NODE_ENV=production
 RUN corepack enable yarn # to read "packageManager" in package.json
 
-FROM base as build
+FROM base AS build
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN --mount=type=cache,target=/root/.cache/yarn/v6 yarn --immutable
 
 COPY . .
 RUN yarn build
 
-FROM base as final
+FROM base AS final
 USER node
 
 COPY --from=build --chown=node:node /app/public ./public
@@ -19,7 +19,7 @@ COPY --from=build --chown=node:node /app/.next/standalone ./
 COPY --from=build --chown=node:node /app/.next/static ./.next/static
 
 EXPOSE 3000
-ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 CMD ["node", "server.js"]

--- a/typing-server/Dockerfile
+++ b/typing-server/Dockerfile
@@ -1,5 +1,5 @@
 # 基本イメージ
-FROM golang:1.23.4 as builder
+FROM golang:1.23.4 AS builder
 
 # 作業ディレクトリを設定
 WORKDIR /app

--- a/typing-server/Dockerfile.dev
+++ b/typing-server/Dockerfile.dev
@@ -1,5 +1,5 @@
 # 基本イメージ
-FROM golang:1.23.4 as builder
+FROM golang:1.23.4 AS builder
 
 # 作業ディレクトリを設定
 WORKDIR /app


### PR DESCRIPTION
## やったこと

- typing-appおよびtyping-serverのDockerfile(.dev)に対して出ていた警告を修正

警告の一例↓

> **The 'as' keyword should match the case of the 'from' keyword**: typing-app/Dockerfile#L14
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match
> More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

([適当な履歴](https://github.com/su-its/typing/actions/runs/13679515770)のAnnotationという欄から見られる)

## 動作確認

- 修正したDockerfile(.dev)に対して`docker build --check`を実行し何も警告が出なくなった