### PR TITLE
fix(server): Unique検索のバグを回避するために、OnlyメソッドをFirstメソッドに変更

### DIFF
--- a/typing-server/internal/infra/ent/repository/ent_score_repository.go
+++ b/typing-server/internal/infra/ent/repository/ent_score_repository.go
@@ -78,7 +78,8 @@ func (r *EntScoreRepository) GetMaxScores(ctx context.Context, userID uuid.UUID)
 	maxKeystrokeScore, err := r.client.Score.Query().
 		WithUser().
 		Where(score.UserID(userID), score.IsMaxKeystrokes(true)).
-		Only(ctx)
+		// TODO: isMaxKeyStorokesとかがUniqueじゃないのが悪さしている https://github.com/su-its/typing/issues/203
+		First(ctx) // NOTE: バグでUniqueで検索するとエラーになるため、Firstで検索する
 	if err != nil && !ent_generated.IsNotFound(err) {
 		return nil, nil, err
 	}
@@ -86,7 +87,8 @@ func (r *EntScoreRepository) GetMaxScores(ctx context.Context, userID uuid.UUID)
 	maxAccuracyScore, err := r.client.Score.Query().
 		WithUser().
 		Where(score.UserID(userID), score.IsMaxAccuracy(true)).
-		Only(ctx)
+		// TODO: isMaxAccuracyとかがUniqueじゃないのが悪さしている https://github.com/su-its/typing/issues/203
+		First(ctx) // NOTE: バグでUniqueで検索するとエラーになるため、Firstで検索する
 	if err != nil && !ent_generated.IsNotFound(err) {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Why
スコア登録に失敗する

## What
最大スコア更新のフラグ判定処理のクエリを修正

isMax系の更新が漏れるケースがあり、Uniqueクエリを使うとエラーになるのでFirstを使う。
対処療法的な方法で根本的にはランキング計算の方法を変えていく必要がある #203 に起票ed