### PR TITLE
fix(server): エラー時のロギングを改善

### DIFF
--- a/typing-server/cmd/server/main.go
+++ b/typing-server/cmd/server/main.go
@@ -81,8 +81,8 @@ func main() {
 
 	// ハンドラの作成
 	healthHandler := handler.NewHealthCheckHandler()
-	userHandler := handler.NewUserHandler(userUseCase)
-	scoreHandler := handler.NewScoreHandler(scoreUseCase)
+	userHandler := handler.NewUserHandler(userUseCase, log)
+	scoreHandler := handler.NewScoreHandler(scoreUseCase, log)
 
 	// ルーターの作成
 	router := interfaces.NewRouter(healthHandler, userHandler, scoreHandler, config)

--- a/typing-server/internal/interfaces/handler/score_handler_test.go
+++ b/typing-server/internal/interfaces/handler/score_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -14,6 +15,7 @@ import (
 func TestNewScoreHandler(t *testing.T) {
 	type args struct {
 		scoreUseCase *usecase.ScoreUseCase
+		log          *slog.Logger
 	}
 	fakeUseCase := &usecase.ScoreUseCase{}
 	tests := []struct {
@@ -26,15 +28,17 @@ func TestNewScoreHandler(t *testing.T) {
 			name: "正常系: ScoreHandlerが正しく生成される",
 			args: args{
 				scoreUseCase: fakeUseCase,
+				log:          slog.Default(),
 			},
 			want: &ScoreHandler{
 				scoreUseCase: fakeUseCase,
+				log:          slog.Default(),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewScoreHandler(tt.args.scoreUseCase); !reflect.DeepEqual(got, tt.want) {
+			if got := NewScoreHandler(tt.args.scoreUseCase, tt.args.log); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewScoreHandler() = %v, want %v", got, tt.want)
 			}
 		})

--- a/typing-server/internal/interfaces/handler/user_handler.go
+++ b/typing-server/internal/interfaces/handler/user_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/su-its/typing/typing-server/internal/domain/usecase"
@@ -11,12 +12,14 @@ import (
 // UserHandler はユーザー関連の HTTP ハンドラ
 type UserHandler struct {
 	userUseCase usecase.IUserUseCase
+	log         *slog.Logger
 }
 
 // NewUserHandler は UserHandler のインスタンスを生成する
-func NewUserHandler(userUseCase usecase.IUserUseCase) *UserHandler {
+func NewUserHandler(userUseCase usecase.IUserUseCase, log *slog.Logger) *UserHandler {
 	return &UserHandler{
 		userUseCase: userUseCase,
+		log:         log,
 	}
 }
 
@@ -38,6 +41,7 @@ func (h *UserHandler) GetUserByStudentNumber(w http.ResponseWriter, r *http.Requ
 		case errors.Is(err, usecase.ErrUserNotFound):
 			http.Error(w, ErrUserNotFound, http.StatusNotFound)
 		default:
+			h.log.Error("GetUserByStudentNumber failed", "error", err)
 			http.Error(w, ErrInternalServer, http.StatusInternalServerError)
 		}
 		return
@@ -50,6 +54,7 @@ func (h *UserHandler) GetUserByStudentNumber(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(user); err != nil {
+		h.log.Error("Failed to encode JSON response", "error", err)
 		http.Error(w, ErrFailedToEncodeResponse, http.StatusInternalServerError)
 	}
 }

--- a/typing-server/internal/interfaces/handler/user_handler_test.go
+++ b/typing-server/internal/interfaces/handler/user_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -20,6 +21,7 @@ import (
 func TestNewUserHandler(t *testing.T) {
 	type args struct {
 		userUseCase usecase.IUserUseCase
+		log         *slog.Logger
 	}
 	tests := []struct {
 		name string
@@ -30,15 +32,17 @@ func TestNewUserHandler(t *testing.T) {
 			name: "正常系: UserHandlerが正しく生成される",
 			args: args{
 				userUseCase: &mockUserUseCase{},
+				log:         slog.Default(),
 			},
 			want: &UserHandler{
 				userUseCase: &mockUserUseCase{},
+				log:         slog.Default(),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewUserHandler(tt.args.userUseCase); !reflect.DeepEqual(got, tt.want) {
+			if got := NewUserHandler(tt.args.userUseCase, tt.args.log); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewUserHandler() = %v, want %v", got, tt.want)
 			}
 		})
@@ -92,6 +96,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 						}, nil
 					},
 				},
+				log: slog.Default(),
 			},
 			args: args{
 				w: httptest.NewRecorder(),
@@ -104,6 +109,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 			name: "異常系: student_numberが指定されていない場合",
 			h: &UserHandler{
 				userUseCase: &usecase.UserUseCase{},
+				log:         slog.Default(),
 			},
 			args: args{
 				w: httptest.NewRecorder(),
@@ -120,6 +126,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 						return nil, usecase.ErrUserNotFound
 					},
 				},
+				log: slog.Default(),
 			},
 			args: args{
 				w: httptest.NewRecorder(),
@@ -136,6 +143,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 						return nil, errors.New("hoge")
 					},
 				},
+				log: slog.Default(),
 			},
 			args: args{
 				w: httptest.NewRecorder(),
@@ -152,6 +160,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 						return nil, nil
 					},
 				},
+				log: slog.Default(),
 			},
 			args: args{
 				w: httptest.NewRecorder(),
@@ -174,6 +183,7 @@ func TestUserHandler_GetUserByStudentNumber(t *testing.T) {
 						}, nil
 					},
 				},
+				log: slog.Default(),
 			},
 			args: args{
 				w: testutils.NewFakeResponseWriter(),

--- a/typing-server/pkg/middleware/logging.go
+++ b/typing-server/pkg/middleware/logging.go
@@ -35,8 +35,23 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(lrw, r)
 
 		duration := time.Since(start)
-		log.Info("Completed request",
-			"status", lrw.statusCode,
-			"duration", duration)
+
+		if lrw.statusCode >= 500 {
+			log.Error("Request failed with server error",
+				"status", lrw.statusCode,
+				"method", r.Method,
+				"url", r.URL.String(),
+				"duration", duration)
+		} else if lrw.statusCode >= 400 {
+			log.Warn("Request failed with client error",
+				"status", lrw.statusCode,
+				"method", r.Method,
+				"url", r.URL.String(),
+				"duration", duration)
+		} else {
+			log.Info("Completed request",
+				"status", lrw.statusCode,
+				"duration", duration)
+		}
 	})
 }


### PR DESCRIPTION
## Why
エラー時に内容を正しくロギングできていなかった

## What
スタック情報などは無いがとりあえず、暫定的にエラー箇所は特定できるレベルでロギングを行う。
またロギングミドルウェアのログタイプのルーティングも修正した