### PR TITLE
feat: ランキングテーブルに表示行数を追加し、データがない場合の表示を改善

### DIFF
--- a/typing-app/src/components/molecules/EmptyTableRow.tsx
+++ b/typing-app/src/components/molecules/EmptyTableRow.tsx
@@ -1,18 +1,20 @@
-import styles from "@/assets/sass/molecules/RankingTableRow.module.scss"; // スタイルを再利用
+import styles from "@/assets/sass/molecules/RankingTableRow.module.scss";
+import type { ColumnDefinition } from "../organism/RankingTabs";
 
-const EmptyTableRow: React.FC = () => {
-	// 表示する列の数を RankingTableRow と合わせる
-	const numberOfColumns = 5; // ランク以外のデータ列の数
+interface EmptyTableRowProps {
+  columns: ColumnDefinition[];
+}
 
-	return (
-		<tr className={styles.row}>
-			<td className={styles.rank}>{String("-")}</td>
-			{/* データがない列は "-" を表示 */}
-			{Array.from({ length: numberOfColumns }).map((_, columnIndex) => (
-				<td key={`empty-cell-column-${columnIndex}`}>-</td>
-			))}
-		</tr>
-	);
+const EmptyTableRow: React.FC<EmptyTableRowProps> = ({ columns }) => {
+  return (
+    <tr className={styles.row}>
+      {columns.map((column, index) => (
+        <td key={column.key} className={index === 0 ? styles.rank : undefined}>
+          -
+        </td>
+      ))}
+    </tr>
+  );
 };
 
 export default EmptyTableRow;

--- a/typing-app/src/components/molecules/RankingTableBody.tsx
+++ b/typing-app/src/components/molecules/RankingTableBody.tsx
@@ -1,30 +1,27 @@
 import RankingTableRow from "./RankingTableRow";
 import EmptyTableRow from "./EmptyTableRow";
 import type { components } from "@/libs/api/v0";
+import type { ColumnDefinition } from "../organism/RankingTabs";
 
 export type RankingTableBodyProps = {
-	scoreRankings: components["schemas"]["ScoreRanking"][];
-	displayRows: number;
+  scoreRankings: components["schemas"]["ScoreRanking"][];
+  displayRows: number;
+  columns: ColumnDefinition[];
 };
 
-const RankingTableBody: React.FC<RankingTableBodyProps> = ({
-	scoreRankings,
-	displayRows,
-}) => {
-	return (
-		<tbody>
-			{Array.from({ length: displayRows }).map((_, index) => {
-				const scoreRanking = scoreRankings[index];
-				if (scoreRanking) {
-					return (
-						<RankingTableRow key={scoreRanking.score.id} {...scoreRanking} />
-					);
-				}
+const RankingTableBody: React.FC<RankingTableBodyProps> = ({ scoreRankings, displayRows, columns }) => {
+  return (
+    <tbody>
+      {Array.from({ length: displayRows }).map((_, index) => {
+        const scoreRanking = scoreRankings[index];
+        if (scoreRanking) {
+          return <RankingTableRow key={scoreRanking.score.id} scoreRanking={scoreRanking} columns={columns} />;
+        }
 
-				return <EmptyTableRow key={`rank-${index}`} />;
-			})}
-		</tbody>
-	);
+        return <EmptyTableRow key={`empty-row-${index}`} columns={columns} />;
+      })}
+    </tbody>
+  );
 };
 
 export default RankingTableBody;

--- a/typing-app/src/components/molecules/RankingTableHead.tsx
+++ b/typing-app/src/components/molecules/RankingTableHead.tsx
@@ -1,15 +1,19 @@
 import styles from "@/assets/sass/molecules/RankingTableHead.module.scss";
+import type { ColumnDefinition } from "../organism/RankingTabs";
 
-const RankingTableHead: React.FC = () => {
+interface RankingTableHeadProps {
+  columns: ColumnDefinition[];
+}
+
+const RankingTableHead: React.FC<RankingTableHeadProps> = ({ columns }) => {
   return (
     <thead className={styles.head}>
       <tr>
-        <th>順位</th>
-        <th>学籍番号</th>
-        <th>名前</th>
-        <th>入力文字数</th>
-        <th>正打率</th>
-        <th>記録日</th>
+        {columns.map((column, index) => (
+          <th key={column.key} className={index === 0 ? styles.rank : undefined}>
+            {column.label}
+          </th>
+        ))}
       </tr>
     </thead>
   );

--- a/typing-app/src/components/molecules/RankingTableRow.tsx
+++ b/typing-app/src/components/molecules/RankingTableRow.tsx
@@ -1,34 +1,36 @@
 import type { components } from "@/libs/api/v0";
 import styles from "@/assets/sass/molecules/RankingTableRow.module.scss";
+import type { ColumnDefinition } from "../organism/RankingTabs";
 
-// 新しい Props 型を定義
-type RankingTableRowProps = components["schemas"]["ScoreRanking"];
+interface RankingTableRowProps {
+  scoreRanking: components["schemas"]["ScoreRanking"];
+  columns: ColumnDefinition[];
+}
 
-// コンポーネントの Props 型を新しい型に変更し、分割代入を使用
-const RankingTableRow: React.FC<RankingTableRowProps> = ({ rank, score }) => {
-	const accuracy = score.accuracy;
+const RankingTableRow: React.FC<RankingTableRowProps> = ({ scoreRanking, columns }) => {
+  return (
+    <tr className={styles.row}>
+      {/* columns に基づいてセルを動的にレンダリング */}
+      {columns.map((column) => {
+        // dataAccessor があればそれを使用し、なければキーでアクセス
+        let cellData: React.ReactNode = null; // 型を ReactNode に
+        if (column.key === "rank") {
+          cellData = scoreRanking.rank;
+        } else if (column.dataAccessor) {
+          cellData = column.dataAccessor(scoreRanking);
+        }
 
-	const formatter = new Intl.NumberFormat("en-US", {
-		style: "percent",
-		maximumFractionDigits: 2,
-	});
+        // rank 列には特別なスタイルを適用
+        const className = column.key === "rank" ? styles.rank : undefined;
 
-	const formattedAccuracy = formatter.format(accuracy);
-
-	const formattedCreatedAt = new Date(score.created_at)
-		.toISOString()
-		.split("T")[0];
-
-	return (
-		<tr className={styles.row}>
-			<td className={styles.rank}>{String(rank)}</td>
-			<td>{score.user.student_number}</td>
-			<td>{score.user.handle_name}</td>
-			<td>{String(score.keystrokes)}</td>
-			<td>{formattedAccuracy}</td>
-			<td>{formattedCreatedAt}</td>
-		</tr>
-	);
+        return (
+          <td key={column.key} className={className}>
+            {cellData}
+          </td>
+        );
+      })}
+    </tr>
+  );
 };
 
 export default RankingTableRow;

--- a/typing-app/src/components/organism/RankingTable.tsx
+++ b/typing-app/src/components/organism/RankingTable.tsx
@@ -1,13 +1,19 @@
 import RankingTableHead from "../molecules/RankingTableHead";
-import RankingTableBody, { RankingTableBodyProps } from "../molecules/RankingTableBody";
+import RankingTableBody from "../molecules/RankingTableBody";
+import type { RankingTableBodyProps } from "../molecules/RankingTableBody";
+import type { ColumnDefinition } from "./RankingTabs";
 import styles from "@/assets/sass/organism/RankingTable.module.scss";
 
-const RankingTable: React.FC<RankingTableBodyProps> = ({ scoreRankings, displayRows }) => {
+interface RankingTableProps extends RankingTableBodyProps {
+  columns: ColumnDefinition[];
+}
+
+const RankingTable: React.FC<RankingTableProps> = ({ scoreRankings, displayRows, columns }) => {
   return (
     <div>
       <table className={styles.ranking}>
-        <RankingTableHead />
-        <RankingTableBody scoreRankings={scoreRankings} displayRows={displayRows} />
+        <RankingTableHead columns={columns} />
+        <RankingTableBody scoreRankings={scoreRankings} displayRows={displayRows} columns={columns} />
       </table>
     </div>
   );


### PR DESCRIPTION
## Why

ランキングが無いときとか、
ページネーションの関係でテーブルデータの数が動的な場合の表示揺れがきになる

## What
ページのルートから行数をPropsリレーする。
行数に満たない場合は - - - のような表示になる。

Propsに与える値はLIMITという定数でこれは、APIリクエストの際にも利用する変数である。


![image](https://github.com/user-attachments/assets/7bc3f5ce-6c36-400c-b9f8-7da08ceaadbf)

![image](https://github.com/user-attachments/assets/ecc8f0c5-b18a-45b4-aa27-6dbfd000d558)
