### PR TITLE
feat: support CSV user imports in seed

### DIFF
--- a/typing-server/Dockerfile.dev
+++ b/typing-server/Dockerfile.dev
@@ -15,6 +15,7 @@ RUN cd internal/infra/ent && go generate
 # アプリケーションをビルド
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o server ./cmd/server/main.go
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o seed ./cmd/seed/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o import-users ./cmd/import-users/main.go
 
 # 実行イメージ
 FROM alpine:latest
@@ -31,6 +32,7 @@ WORKDIR /root
 # ビルドしたバイナリをコピー
 COPY --from=builder /app/server .
 COPY --from=builder /app/seed .
+COPY --from=builder /app/import-users .
 
 # アプリケーションの実行
 CMD ["./server"]

--- a/typing-server/Makefile
+++ b/typing-server/Makefile
@@ -13,7 +13,7 @@ import-users:
 		exit 1; \
 	fi
 	@echo "CSVからユーザーを投入しています..."
-	DB_ADDR=$${DB_ADDR:-127.0.0.1:3307} go run ./cmd/seed/main.go -csv "$(CSV)"
+	DB_ADDR=$${DB_ADDR:-127.0.0.1:3307} go run ./cmd/import-users/main.go -csv "$(CSV)"
 	@echo "CSVからのユーザー投入が完了しました"
 
 # ヘルプコマンド

--- a/typing-server/Makefile
+++ b/typing-server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate seed connect up-with-build help db-drop-dev db-reset-dev db-clean-dev
+.PHONY: generate seed import-users connect up-with-build help db-drop-dev db-reset-dev db-clean-dev
 generate:
 	cd internal/infra/ent && go generate
 
@@ -7,11 +7,21 @@ seed:
 	docker compose -f docker-compose.dev.yml run --rm seed
 	@echo "シードデータの投入が完了しました"
 
+import-users:
+	@if [ -z "$(CSV)" ]; then \
+		echo "CSV=/path/to/file.csv を指定してください"; \
+		exit 1; \
+	fi
+	@echo "CSVからユーザーを投入しています..."
+	DB_ADDR=$${DB_ADDR:-127.0.0.1:3307} go run ./cmd/seed/main.go -csv "$(CSV)"
+	@echo "CSVからのユーザー投入が完了しました"
+
 # ヘルプコマンド
 help:
 	@echo "使用可能なコマンド:"
 	@echo "  generate       - entのコード生成を実行する"
 	@echo "  seed           - 開発環境にシードデータを投入する"
+	@echo "  import-users   - CSVからユーザーを投入する（CSV=/path/to/file.csv を指定）"
 	@echo "  connect        - 開発環境に接続する"
 	@echo "  up-with-build  - 開発環境を起動する"
 	@echo "  db-drop-dev    - 開発環境のデータベースのテーブルをドロップする"

--- a/typing-server/README.md
+++ b/typing-server/README.md
@@ -52,7 +52,7 @@ make up-with-build
 `学籍番号,氏名` の2列CSVからユーザーを作成するコマンドを追加しています。`2026.csv` のようなヘッダーなしCSVに加えて、`student_number,handle_name` のようなヘッダー付きCSVも読み込めます。
 
 ```bash
-DB_ADDR=127.0.0.1:3307 go run ./cmd/seed/main.go -csv ~/Downloads/2026.csv
+DB_ADDR=127.0.0.1:3307 go run ./cmd/import-users/main.go -csv ~/Downloads/2026.csv
 ```
 
 または `Makefile` 経由で次のように実行できます。

--- a/typing-server/README.md
+++ b/typing-server/README.md
@@ -47,6 +47,22 @@ make up-with-build
 
 そのほかのコマンドは `Makefile` を参照するか `make help` を実行してください。
 
+## CSVからユーザーをインポートする
+
+`学籍番号,氏名` の2列CSVからユーザーを作成するコマンドを追加しています。`2026.csv` のようなヘッダーなしCSVに加えて、`student_number,handle_name` のようなヘッダー付きCSVも読み込めます。
+
+```bash
+DB_ADDR=127.0.0.1:3307 go run ./cmd/seed/main.go -csv ~/Downloads/2026.csv
+```
+
+または `Makefile` 経由で次のように実行できます。
+
+```bash
+make import-users CSV=~/Downloads/2026.csv
+```
+
+既に存在する学籍番号はスキップし、それ以外は `UserRepository` 経由で作成します。
+
 ## ディレクトリ構造
 
 ```

--- a/typing-server/cmd/import-users/main.go
+++ b/typing-server/cmd/import-users/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/su-its/typing/typing-server/config"
+	"github.com/su-its/typing/typing-server/internal/infra/ent/ent_generated"
+	entrepo "github.com/su-its/typing/typing-server/internal/infra/ent/repository"
+	"github.com/su-its/typing/typing-server/internal/seed/userimport"
+	"github.com/su-its/typing/typing-server/pkg/logger"
+)
+
+func main() {
+	var csvPath string
+	var createSchema bool
+
+	flag.StringVar(&csvPath, "csv", "", "インポートするCSVファイルのパス")
+	flag.BoolVar(&createSchema, "createSchema", true, "起動時にスキーマを作成する")
+	flag.Parse()
+
+	if csvPath == "" {
+		fmt.Println("エラー: -csv は必須です")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	logr := logger.New()
+	cfg := config.New()
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		logr.Error("タイムゾーンのロードに失敗", "error", err, "timezone", "Asia/Tokyo")
+		os.Exit(1)
+	}
+
+	users, err := userimport.LoadUsersFromCSV(csvPath)
+	if err != nil {
+		logr.Error("CSVの読み込みに失敗", "error", err, "csv", csvPath)
+		os.Exit(1)
+	}
+
+	mysqlConfig := &mysql.Config{
+		DBName:               "typing-db",
+		User:                 "user",
+		Passwd:               "password",
+		Net:                  "tcp",
+		Addr:                 cfg.DBAddr,
+		ParseTime:            true,
+		Loc:                  jst,
+		AllowNativePasswords: true,
+		TLSConfig:            "false",
+	}
+
+	entClient, err := ent_generated.Open("mysql", mysqlConfig.FormatDSN())
+	if err != nil {
+		logr.Error("データベース接続に失敗", "error", err, "config", mysqlConfig.FormatDSN())
+		os.Exit(1)
+	}
+	defer entClient.Close()
+
+	ctx := context.Background()
+	if createSchema {
+		if err := entClient.Schema.Create(ctx); err != nil {
+			logr.Error("スキーマ作成に失敗", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	userRepo := entrepo.NewEntUserRepository(entClient)
+	summary, err := userimport.SeedUsers(ctx, userRepo, users)
+	if err != nil {
+		logr.Error("ユーザーインポートに失敗", "error", err, "csv", csvPath)
+		os.Exit(1)
+	}
+
+	logr.Info(
+		"ユーザーインポート完了",
+		"environment", cfg.Environment,
+		"db_addr", cfg.DBAddr,
+		"csv", csvPath,
+		"total", summary.Total,
+		"created", summary.Created,
+		"skipped", summary.Skipped,
+	)
+}

--- a/typing-server/cmd/seed/main.go
+++ b/typing-server/cmd/seed/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log/slog"
 	"math/rand"
 	"os"
 	"sync"
@@ -18,7 +17,6 @@ import (
 	"github.com/su-its/typing/typing-server/internal/domain/usecase"
 	"github.com/su-its/typing/typing-server/internal/infra/ent/ent_generated"
 	"github.com/su-its/typing/typing-server/internal/infra/ent/repository"
-	"github.com/su-its/typing/typing-server/internal/seed/userimport"
 	"github.com/su-its/typing/typing-server/pkg/logger"
 )
 
@@ -29,26 +27,22 @@ func main() {
 	var minKeystrokes int
 	var minAccuracy float64
 	var maxConcurrent int
-	var csvPath string
 	flag.IntVar(&numUsers, "users", 0, "シードするユーザー数")
 	flag.IntVar(&numScores, "scores", 0, "1ユーザーあたりにシードするスコア数")
 	flag.IntVar(&minKeystrokes, "minKeystrokes", 0, "各ユーザーに登録する最低スコア（keystrokes）の下限値")
 	flag.Float64Var(&minAccuracy, "minAccuracy", 0.95, "各ユーザーに登録するaccuracyの最低値（0.0〜1.0）")
 	flag.IntVar(&maxConcurrent, "concurrent", 10, "同時実行するgoroutineの最大数")
-	flag.StringVar(&csvPath, "csv", "", "ユーザーをインポートするCSVファイルのパス")
 	flag.Parse()
 
-	if csvPath == "" {
-		if numUsers <= 0 || numScores <= 0 || minKeystrokes <= 0 {
-			fmt.Println("エラー: -users と -scores と -minKeystrokes は正の整数で指定してください")
-			flag.Usage()
-			os.Exit(1)
-		}
-		if minAccuracy < 0.0 || minAccuracy >= 1.0 {
-			fmt.Println("エラー: -minAccuracy は0.0以上1.0未満で指定してください")
-			flag.Usage()
-			os.Exit(1)
-		}
+	if numUsers <= 0 || numScores <= 0 || minKeystrokes <= 0 {
+		fmt.Println("エラー: -users と -scores と -minKeystrokes は正の整数で指定してください")
+		flag.Usage()
+		os.Exit(1)
+	}
+	if minAccuracy < 0.0 || minAccuracy >= 1.0 {
+		fmt.Println("エラー: -minAccuracy は0.0以上1.0未満で指定してください")
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	// ログ・設定の初期化
@@ -94,47 +88,12 @@ func main() {
 	logr.Info("スキーマ作成成功")
 
 	// 各種リポジトリ・ユースケースの初期化
-	userRepo := repository.NewEntUserRepository(entClient)
-
-	if csvPath != "" {
-		logr.Info("CSVからのユーザー投入開始", "csv", csvPath)
-
-		users, err := userimport.LoadUsersFromCSV(csvPath)
-		if err != nil {
-			logr.Error("CSVの読み込みに失敗", "error", err, "csv", csvPath)
-			os.Exit(1)
-		}
-
-		summary, err := userimport.SeedUsers(ctx, userRepo, users)
-		if err != nil {
-			logr.Error("CSVからのユーザー投入に失敗", "error", err, "csv", csvPath)
-			os.Exit(1)
-		}
-
-		logr.Info("CSVからのユーザー投入完了", "csv", csvPath, "total", summary.Total, "created", summary.Created, "skipped", summary.Skipped)
-		return
-	}
-
 	txManager := repository.NewEntTxManager(entClient)
+	userRepo := repository.NewEntUserRepository(entClient)
 	scoreRepo := repository.NewEntScoreRepository(entClient)
 	scoreService := service.NewScoreService(scoreRepo)
 	userUseCase := usecase.NewUserUseCase(userRepo)
 	scoreUseCase := usecase.NewScoreUseCase(txManager, scoreRepo, scoreService)
-
-	seedRandomUsersAndScores(ctx, logr, userUseCase, scoreUseCase, numUsers, numScores, minKeystrokes, minAccuracy, maxConcurrent)
-}
-
-func seedRandomUsersAndScores(
-	ctx context.Context,
-	logr *slog.Logger,
-	userUseCase *usecase.UserUseCase,
-	scoreUseCase *usecase.ScoreUseCase,
-	numUsers int,
-	numScores int,
-	minKeystrokes int,
-	minAccuracy float64,
-	maxConcurrent int,
-) {
 	var wg sync.WaitGroup
 
 	// ユーザー作成とスコア登録処理を並列化

--- a/typing-server/cmd/seed/main.go
+++ b/typing-server/cmd/seed/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"os"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"github.com/su-its/typing/typing-server/internal/domain/usecase"
 	"github.com/su-its/typing/typing-server/internal/infra/ent/ent_generated"
 	"github.com/su-its/typing/typing-server/internal/infra/ent/repository"
+	"github.com/su-its/typing/typing-server/internal/seed/userimport"
 	"github.com/su-its/typing/typing-server/pkg/logger"
 )
 
@@ -27,22 +29,26 @@ func main() {
 	var minKeystrokes int
 	var minAccuracy float64
 	var maxConcurrent int
+	var csvPath string
 	flag.IntVar(&numUsers, "users", 0, "シードするユーザー数")
 	flag.IntVar(&numScores, "scores", 0, "1ユーザーあたりにシードするスコア数")
 	flag.IntVar(&minKeystrokes, "minKeystrokes", 0, "各ユーザーに登録する最低スコア（keystrokes）の下限値")
 	flag.Float64Var(&minAccuracy, "minAccuracy", 0.95, "各ユーザーに登録するaccuracyの最低値（0.0〜1.0）")
 	flag.IntVar(&maxConcurrent, "concurrent", 10, "同時実行するgoroutineの最大数")
+	flag.StringVar(&csvPath, "csv", "", "ユーザーをインポートするCSVファイルのパス")
 	flag.Parse()
 
-	if numUsers <= 0 || numScores <= 0 || minKeystrokes <= 0 {
-		fmt.Println("エラー: -users と -scores と -minKeystrokes は正の整数で指定してください")
-		flag.Usage()
-		os.Exit(1)
-	}
-	if minAccuracy < 0.0 || minAccuracy >= 1.0 {
-		fmt.Println("エラー: -minAccuracy は0.0以上1.0未満で指定してください")
-		flag.Usage()
-		os.Exit(1)
+	if csvPath == "" {
+		if numUsers <= 0 || numScores <= 0 || minKeystrokes <= 0 {
+			fmt.Println("エラー: -users と -scores と -minKeystrokes は正の整数で指定してください")
+			flag.Usage()
+			os.Exit(1)
+		}
+		if minAccuracy < 0.0 || minAccuracy >= 1.0 {
+			fmt.Println("エラー: -minAccuracy は0.0以上1.0未満で指定してください")
+			flag.Usage()
+			os.Exit(1)
+		}
 	}
 
 	// ログ・設定の初期化
@@ -88,13 +94,47 @@ func main() {
 	logr.Info("スキーマ作成成功")
 
 	// 各種リポジトリ・ユースケースの初期化
-	txManager := repository.NewEntTxManager(entClient)
 	userRepo := repository.NewEntUserRepository(entClient)
+
+	if csvPath != "" {
+		logr.Info("CSVからのユーザー投入開始", "csv", csvPath)
+
+		users, err := userimport.LoadUsersFromCSV(csvPath)
+		if err != nil {
+			logr.Error("CSVの読み込みに失敗", "error", err, "csv", csvPath)
+			os.Exit(1)
+		}
+
+		summary, err := userimport.SeedUsers(ctx, userRepo, users)
+		if err != nil {
+			logr.Error("CSVからのユーザー投入に失敗", "error", err, "csv", csvPath)
+			os.Exit(1)
+		}
+
+		logr.Info("CSVからのユーザー投入完了", "csv", csvPath, "total", summary.Total, "created", summary.Created, "skipped", summary.Skipped)
+		return
+	}
+
+	txManager := repository.NewEntTxManager(entClient)
 	scoreRepo := repository.NewEntScoreRepository(entClient)
 	scoreService := service.NewScoreService(scoreRepo)
 	userUseCase := usecase.NewUserUseCase(userRepo)
 	scoreUseCase := usecase.NewScoreUseCase(txManager, scoreRepo, scoreService)
 
+	seedRandomUsersAndScores(ctx, logr, userUseCase, scoreUseCase, numUsers, numScores, minKeystrokes, minAccuracy, maxConcurrent)
+}
+
+func seedRandomUsersAndScores(
+	ctx context.Context,
+	logr *slog.Logger,
+	userUseCase *usecase.UserUseCase,
+	scoreUseCase *usecase.ScoreUseCase,
+	numUsers int,
+	numScores int,
+	minKeystrokes int,
+	minAccuracy float64,
+	maxConcurrent int,
+) {
 	var wg sync.WaitGroup
 
 	// ユーザー作成とスコア登録処理を並列化

--- a/typing-server/internal/seed/userimport/csv.go
+++ b/typing-server/internal/seed/userimport/csv.go
@@ -1,0 +1,133 @@
+package userimport
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/su-its/typing/typing-server/internal/domain/model"
+)
+
+const maxHandleNameLength = 36
+
+func LoadUsersFromCSV(path string) ([]model.User, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open csv: %w", err)
+	}
+	defer file.Close()
+
+	users, err := ParseUsersCSV(file)
+	if err != nil {
+		return nil, fmt.Errorf("parse csv %q: %w", path, err)
+	}
+
+	return users, nil
+}
+
+func ParseUsersCSV(r io.Reader) ([]model.User, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+	reader.TrimLeadingSpace = true
+
+	var users []model.User
+	seenStudentNumbers := make(map[string]int)
+	rowNumber := 0
+
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("row %d: %w", rowNumber+1, err)
+		}
+
+		rowNumber++
+		if isBlankRecord(record) {
+			continue
+		}
+		if len(record) < 2 {
+			return nil, fmt.Errorf("row %d: expected at least 2 columns, got %d", rowNumber, len(record))
+		}
+
+		studentNumber := normalizeCSVCell(record[0])
+		handleName := normalizeCSVCell(record[1])
+
+		if isHeaderRow(studentNumber, handleName) {
+			continue
+		}
+		if studentNumber == "" {
+			return nil, fmt.Errorf("row %d: student number is empty", rowNumber)
+		}
+		if handleName == "" {
+			return nil, fmt.Errorf("row %d: handle name is empty", rowNumber)
+		}
+		if utf8.RuneCountInString(handleName) > maxHandleNameLength {
+			return nil, fmt.Errorf("row %d: handle name exceeds %d characters", rowNumber, maxHandleNameLength)
+		}
+
+		if firstSeenRow, exists := seenStudentNumbers[studentNumber]; exists {
+			return nil, fmt.Errorf("row %d: duplicate student number %q (first seen at row %d)", rowNumber, studentNumber, firstSeenRow)
+		}
+		seenStudentNumbers[studentNumber] = rowNumber
+
+		users = append(users, model.User{
+			StudentNumber: studentNumber,
+			HandleName:    handleName,
+		})
+	}
+
+	if len(users) == 0 {
+		return nil, errors.New("no users found in csv")
+	}
+
+	return users, nil
+}
+
+func normalizeCSVCell(value string) string {
+	return strings.TrimSpace(strings.TrimPrefix(value, "\uFEFF"))
+}
+
+func isBlankRecord(record []string) bool {
+	for _, cell := range record {
+		if normalizeCSVCell(cell) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func isHeaderRow(studentNumber string, handleName string) bool {
+	normalizedStudentNumber := normalizeHeaderCell(studentNumber)
+	normalizedHandleName := normalizeHeaderCell(handleName)
+
+	return isStudentNumberHeader(normalizedStudentNumber) && isHandleNameHeader(normalizedHandleName)
+}
+
+func normalizeHeaderCell(value string) string {
+	replacer := strings.NewReplacer("_", "", "-", "", " ", "", "\u3000", "")
+	return strings.ToLower(replacer.Replace(normalizeCSVCell(value)))
+}
+
+func isStudentNumberHeader(value string) bool {
+	switch value {
+	case "studentnumber", "学籍番号":
+		return true
+	default:
+		return false
+	}
+}
+
+func isHandleNameHeader(value string) bool {
+	switch value {
+	case "handlename", "name", "氏名", "名前":
+		return true
+	default:
+		return false
+	}
+}

--- a/typing-server/internal/seed/userimport/csv_test.go
+++ b/typing-server/internal/seed/userimport/csv_test.go
@@ -1,0 +1,80 @@
+package userimport
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseUsersCSV(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		csv         string
+		wantCount   int
+		wantFirstID string
+		wantFirstHN string
+		wantErr     string
+	}{
+		{
+			name:        "headerなしの2列CSVを読み込める",
+			csv:         "\uFEFF725A0701,AUNG BHONE PYAE KYAW\n726A0001,青山　哲\n",
+			wantCount:   2,
+			wantFirstID: "725A0701",
+			wantFirstHN: "AUNG BHONE PYAE KYAW",
+		},
+		{
+			name:        "header行を読み飛ばせる",
+			csv:         "student_number,handle_name\n725A0701,AUNG BHONE PYAE KYAW\n",
+			wantCount:   1,
+			wantFirstID: "725A0701",
+			wantFirstHN: "AUNG BHONE PYAE KYAW",
+		},
+		{
+			name:    "列不足はエラー",
+			csv:     "725A0701\n",
+			wantErr: "expected at least 2 columns",
+		},
+		{
+			name:    "重複学籍番号はエラー",
+			csv:     "725A0701,AUNG BHONE PYAE KYAW\n725A0701,青山　哲\n",
+			wantErr: "duplicate student number",
+		},
+		{
+			name:    "空ファイルはエラー",
+			csv:     "\n",
+			wantErr: "no users found in csv",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseUsersCSV(strings.NewReader(tt.csv))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseUsersCSV() error = nil, want substring %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseUsersCSV() error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseUsersCSV() error = %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Fatalf("ParseUsersCSV() count = %d, want %d", len(got), tt.wantCount)
+			}
+			if got[0].StudentNumber != tt.wantFirstID {
+				t.Fatalf("ParseUsersCSV() first studentNumber = %q, want %q", got[0].StudentNumber, tt.wantFirstID)
+			}
+			if got[0].HandleName != tt.wantFirstHN {
+				t.Fatalf("ParseUsersCSV() first handleName = %q, want %q", got[0].HandleName, tt.wantFirstHN)
+			}
+		})
+	}
+}

--- a/typing-server/internal/seed/userimport/importer.go
+++ b/typing-server/internal/seed/userimport/importer.go
@@ -1,0 +1,41 @@
+package userimport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/su-its/typing/typing-server/internal/domain/model"
+	"github.com/su-its/typing/typing-server/internal/domain/repository"
+)
+
+type Summary struct {
+	Total   int
+	Created int
+	Skipped int
+}
+
+func SeedUsers(ctx context.Context, userRepo repository.UserRepository, users []model.User) (Summary, error) {
+	summary := Summary{Total: len(users)}
+
+	for _, user := range users {
+		if user.StudentNumber == "" {
+			return summary, errors.New("student number is empty")
+		}
+		if user.HandleName == "" {
+			return summary, fmt.Errorf("handle name is empty for student number %q", user.StudentNumber)
+		}
+
+		_, err := userRepo.CreateUser(ctx, user.StudentNumber, user.HandleName)
+		switch {
+		case err == nil:
+			summary.Created++
+		case errors.Is(err, repository.ErrUserAlreadyExists):
+			summary.Skipped++
+		default:
+			return summary, fmt.Errorf("create user %q: %w", user.StudentNumber, err)
+		}
+	}
+
+	return summary, nil
+}

--- a/typing-server/internal/seed/userimport/importer_test.go
+++ b/typing-server/internal/seed/userimport/importer_test.go
@@ -1,0 +1,76 @@
+package userimport
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/su-its/typing/typing-server/internal/domain/model"
+	"github.com/su-its/typing/typing-server/internal/domain/repository"
+)
+
+type stubUserRepository struct {
+	createFn func(ctx context.Context, studentNumber string, handleName string) (*model.User, error)
+}
+
+func (s stubUserRepository) GetUserByStudentNumber(ctx context.Context, studentNumber string) (*model.User, error) {
+	return nil, nil
+}
+
+func (s stubUserRepository) CreateUser(ctx context.Context, studentNumber string, handleName string) (*model.User, error) {
+	return s.createFn(ctx, studentNumber, handleName)
+}
+
+func TestSeedUsers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("新規作成と既存スキップを集計できる", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		repo := stubUserRepository{
+			createFn: func(ctx context.Context, studentNumber string, handleName string) (*model.User, error) {
+				callCount++
+				if studentNumber == "726A0002" {
+					return nil, repository.ErrUserAlreadyExists
+				}
+				return &model.User{StudentNumber: studentNumber, HandleName: handleName}, nil
+			},
+		}
+
+		summary, err := SeedUsers(context.Background(), repo, []model.User{
+			{StudentNumber: "726A0001", HandleName: "青山　哲"},
+			{StudentNumber: "726A0002", HandleName: "浅井　秀羽"},
+		})
+		if err != nil {
+			t.Fatalf("SeedUsers() error = %v", err)
+		}
+		if callCount != 2 {
+			t.Fatalf("SeedUsers() callCount = %d, want 2", callCount)
+		}
+		if summary.Total != 2 || summary.Created != 1 || summary.Skipped != 1 {
+			t.Fatalf("SeedUsers() summary = %+v, want Total=2 Created=1 Skipped=1", summary)
+		}
+	})
+
+	t.Run("予期しないエラーは返す", func(t *testing.T) {
+		t.Parallel()
+
+		repo := stubUserRepository{
+			createFn: func(ctx context.Context, studentNumber string, handleName string) (*model.User, error) {
+				return nil, errors.New("db is down")
+			},
+		}
+
+		_, err := SeedUsers(context.Background(), repo, []model.User{
+			{StudentNumber: "726A0001", HandleName: "青山　哲"},
+		})
+		if err == nil {
+			t.Fatal("SeedUsers() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "create user") {
+			t.Fatalf("SeedUsers() error = %q, want substring %q", err.Error(), "create user")
+		}
+	})
+}


### PR DESCRIPTION
## What changed
- added CSV import mode to `typing-server/cmd/seed/main.go` via `-csv`
- added CSV parsing and repository-based user import helpers under `typing-server/internal/seed/userimport`
- added tests for CSV parsing and import summary behavior
- documented the new import flow in `typing-server/README.md` and exposed it via `make import-users`

## Why
The backend could seed random users and scores, but it could not ingest real student roster CSV files like `2026.csv` and create `User` records through the existing repository interface.

## Impact
Operators can now import real user seed data from roster CSVs without bypassing the repository layer. Existing random score seeding remains available when `-csv` is not specified.

## Checks
- `go generate ./internal/infra/ent`
- `go test ./cmd/seed ./internal/seed/userimport`
