### PR TITLE
ログインエラー時にメッセージが出ないのでテキストで代替するようにした

### DIFF
--- a/typing-app/src/app/actions.ts
+++ b/typing-app/src/app/actions.ts
@@ -21,8 +21,8 @@ export async function login(_: LoginActionState, formData: FormData): Promise<Lo
       },
     });
     if (error || !data) {
-      if (/ユーザーが見つかりません/.test(`${error}`.toLowerCase())) {
-        return { error: "見つかりませんでした" };
+      if (typeof error === "string") {
+        return { error: error };
       }
       return { error: "もう一度お試しください" };
     }

--- a/typing-app/src/app/actions.ts
+++ b/typing-app/src/app/actions.ts
@@ -21,7 +21,7 @@ export async function login(_: LoginActionState, formData: FormData): Promise<Lo
       },
     });
     if (error || !data) {
-      if (/not found/.test(`${error}`.toLowerCase())) {
+      if (/ユーザーが見つかりません/.test(`${error}`.toLowerCase())) {
         return { error: "見つかりませんでした" };
       }
       return { error: "もう一度お試しください" };

--- a/typing-app/src/components/molecules/LoginModal.tsx
+++ b/typing-app/src/components/molecules/LoginModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useActionState } from "react";
 import { login } from "@/app/actions";
-import { showWarningToast } from "@/utils/toast";
+//import { showWarningToast } from "@/utils/toast"; // FIXME: showWarningToast がちゃんと出ないことがある
 import styles from "@/assets/sass/molecules/LoginModal.module.scss";
 
 interface LoginModalProps {
@@ -13,7 +13,7 @@ interface LoginModalProps {
   pending: boolean;
 }
 
-const LoginModalPresenter: React.FC<LoginModalProps> = ({ isOpen, onClose, state, dispatchAction, pending }) => {
+const LoginModalPresenter: React.FC<LoginModalProps> = ({ isOpen, onClose, state, dispatchAction }) => {
   return (
     <>
       {isOpen && (
@@ -21,9 +21,8 @@ const LoginModalPresenter: React.FC<LoginModalProps> = ({ isOpen, onClose, state
           <div className={styles.overlay}></div>
           <div className={styles.content}>
             <form
-              action={async (formData: FormData) => {
-                await dispatchAction(formData);
-                state.error && showWarningToast(state.error);
+              action={(formData: FormData) => {
+                return dispatchAction(formData);
               }}
             >
               <div className={styles.header}>続けるにはログインが必要です</div>
@@ -37,6 +36,8 @@ const LoginModalPresenter: React.FC<LoginModalProps> = ({ isOpen, onClose, state
                   title="学籍番号"
                   role="textbox"
                 />
+                {/* FIXME: 一度 state.error に値が入ると次にモーダルを開いたときに前の state.error が表示されてしまう */}
+                {state.error && <span><sub>{state.error}</sub></span>}
               </div>
               <div className={styles.footer}>
                 <button className={`${styles.button} ${styles.blue}`} role="submit">

--- a/typing-app/src/components/molecules/LoginModal.tsx
+++ b/typing-app/src/components/molecules/LoginModal.tsx
@@ -37,7 +37,11 @@ const LoginModalPresenter: React.FC<LoginModalProps> = ({ isOpen, onClose, state
                   role="textbox"
                 />
                 {/* FIXME: 一度 state.error に値が入ると次にモーダルを開いたときに前の state.error が表示されてしまう */}
-                {state.error && <span><sub>{state.error}</sub></span>}
+                {state.error && (
+                  <span>
+                    <sub>{state.error}</sub>
+                  </span>
+                )}
               </div>
               <div className={styles.footer}>
                 <button className={`${styles.button} ${styles.blue}`} role="submit">


### PR DESCRIPTION
## チケットへのリンク

- ない

ログインしようとして，存在しない学籍番号を入れたとき(=ログインエラー)，エラーも何も表示されないという症状があった(本来であればトーストが出るはずである)．

[recording-2026-04-09-202801.webm](https://github.com/user-attachments/assets/49c95349-29f2-4095-bf1f-021345f31107)


## やったこと

- 原因がわからなかった，かつ時間がないので，ログインエラー時にはエラーメッセージ(「見つかりませんでした」等)をトーストを使わずテキストとして出すように変更した
  - エラーメッセージ自体はもともとのやつを流用．表示だけできないというのが今回解決したい問題．
  - これによるregressionとして，一度ログインしようとしてログインエラーに見舞われた際，モーダルを閉じても，開いた時にはそのテキストが残ってしまう，というのが発生した(コメントに書いた)．
  - エラー時にユーザにフィードバックが無いよりはましだろうということで残す判断をした．

## やらないこと

- 上記regressionの解消

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

[recording-2026-04-09-202014.webm](https://github.com/user-attachments/assets/0b73285d-5df8-4e1e-8229-0c0f16bfd6ce)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/typing/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
