### PR TITLE
chore: update CODEOWNERS to @KikyoNanakusa

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @KinjiKawaguchi @araaki12345
+* @KinjiKawaguchi @KikyoNanakusa


### PR DESCRIPTION
## Why

CODEOWNERS の `@araaki12345` を現室長である `@KikyoNanakusa`（https://github.com/KikyoNanakusa）に差し替える。

## What

- `CODEOWNERS` の1行を更新: `@araaki12345` → `@KikyoNanakusa`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/typing/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
